### PR TITLE
Fix breeze kvstore nodes oputput

### DIFF
--- a/openr/py/openr/cli/commands/kvstore.py
+++ b/openr/py/openr/cli/commands/kvstore.py
@@ -218,7 +218,7 @@ class NodesCmd(KvStoreCmd):
 
             marker = '* ' if prefix_db.thisNodeName == host_id else '> '
             row = ["{}{}".format(marker, prefix_db.thisNodeName)]
-            row.extend(prefix_strs)
+            row.extend(map(lambda l: l.split()[0], prefix_strs.splitlines()[2:]))
             rows.append(row)
 
         rows = []

--- a/openr/py/openr/cli/commands/kvstore.py
+++ b/openr/py/openr/cli/commands/kvstore.py
@@ -218,7 +218,9 @@ class NodesCmd(KvStoreCmd):
 
             marker = '* ' if prefix_db.thisNodeName == host_id else '> '
             row = ["{}{}".format(marker, prefix_db.thisNodeName)]
-            row.extend(map(lambda l: l.split()[0], prefix_strs.splitlines()[2:]))
+            loopback_prefixes = [p.prefix for p in prefix_db.prefixEntries \
+                     if p.type == lsdb_types.PrefixType.LOOPBACK]
+            row.extend([utils.sprint_prefix(p) for p in loopback_prefixes])
             rows.append(row)
 
         rows = []

--- a/openr/py/openr/cli/commands/kvstore.py
+++ b/openr/py/openr/cli/commands/kvstore.py
@@ -213,9 +213,6 @@ class NodesCmd(KvStoreCmd):
         def _parse_nodes(rows, value):
             prefix_db = deserialize_thrift_object(value.value,
                                                   lsdb_types.PrefixDatabase)
-
-            prefix_strs = utils.sprint_prefixes_db_full(prefix_db, True)
-
             marker = '* ' if prefix_db.thisNodeName == host_id else '> '
             row = ["{}{}".format(marker, prefix_db.thisNodeName)]
             loopback_prefixes = [p.prefix for p in prefix_db.prefixEntries \


### PR DESCRIPTION
Description:
- `breeze kvstore nodes` returned ugly output because the original code extended a list of string objects with a unicode object (`prefix_strs`).
- Fixed it so as to pass a properly formatted list of loopback addresses as an argument instead of `prefix_strs`.

Test Plan:
- ran the command on my lab setup and confirmed the fix.

```
$ breeze kvstore nodes
Node             V6-Loopback      V4-Loopback
---------------  ---------------  -------------
* ubuntu-opnr-1  2001:db8::1/128  10.0.0.1/32
> ubuntu-opnr-2  2001:db8::2/128  10.0.0.2/32
> ubuntu-opnr-3  2001:db8::3/128  10.0.0.3/32
```

