### PR TITLE
Fix glog command line arguments on a clean build

### DIFF
--- a/build/build_openr.sh
+++ b/build/build_openr.sh
@@ -316,8 +316,8 @@ sudo apt-get install -y libdouble-conversion-dev \
 # install other dependencies from source
 #
 
-install_glog
 install_gflags
+install_glog # Requires gflags to be build first
 install_gtest
 install_mstch
 install_zstd


### PR DESCRIPTION
To support glog's command line arguments like --logtostderr, it requires gflags.

If gflags is not found, glog will still compile but the command line arguments will be absent.

As glog was created before gflags, that was the case on a clean build.
Note that on subsequent builds gflags already existed, so a second build 'magically' made the command line arguments appear.

Pull Request Template
Title: glog flags like --logtostderr are missing on a clean build

Description:

See facebook/openr#28

Test Plan:

On my OpenR code I compiled it before and after the reorder, and noticed the different behavior.

Pull Request Guideline
Before sending a pull request make sure each commit solves one clear, minimal,
plausible problem. Further each commit should have the above format.
Please avoid sending a pull request with recursive merge nodes, as they
are impossible to fix once merged. Please rebase your branch on
facebook/openr master instead of merging it.
If you are a new contributor please have a look at our contributing guidelines:
CONTRIBUTING