### PR TITLE
Run breeze failed

### DIFF
--- a/build/build_openr.sh
+++ b/build/build_openr.sh
@@ -286,6 +286,7 @@ install_openr() {
   cd "$BUILD_DIR/../openr/py"
   sudo pip install cffi
   sudo pip install future
+  sudo pip install --upgrade typing
   python setup.py build
   sudo python setup.py install
   cd "$BUILD_DIR"


### PR DESCRIPTION
# Issue Description
Run breeze failed on ubuntu 18.04.

```
~/Documents/openr/build$ breeze 
Traceback (most recent call last):
  File "/usr/local/bin/breeze", line 11, in <module>
    load_entry_point('py-openr==1.0', 'console_scripts', 'breeze')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 480, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2693, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2324, in load
    return self.resolve()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2330, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "build/bdist.linux-x86_64/egg/openr/cli/breeze.py", line 24, in <module>
  File "build/bdist.linux-x86_64/egg/openr/cli/clis/config.py", line 18, in <module>
  File "build/bdist.linux-x86_64/egg/openr/cli/commands/config.py", line 19, in <module>
  File "build/bdist.linux-x86_64/egg/openr/utils/serializer.py", line 15, in <module>
  File "/usr/local/lib/python2.7/dist-packages/thrift/util/Serializer.py", line 25, in <module>
    from typing import Any, AnyStr, TypeVar  # noqa: F401
ImportError: No module named typing
```

# Environment
OS version:  Ubuntu 18.04

# Solution
```shell
sudo pip install --upgrade typing
```
