### PR TITLE
[debian-system-builder] Fix debian system builder and install python modules

### DIFF
--- a/build/debian_system_builder/debian_specs/python_fbthrift.py
+++ b/build/debian_system_builder/debian_specs/python_fbthrift.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# Copyright (c) Facebook, Inc. and its affiliates.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import specs.fbthrift as fbthrift
+
+from shell_quoting import ShellQuoted, path_join
+
+
+def fbcode_builder_spec(builder):
+    return {
+        'depends_on': [fbthrift],
+        'steps': [
+            builder.step(
+                "Install thrift python modules",
+                [
+                    builder.workdir(
+                        path_join(
+                            builder.option('projects_dir'),
+                            "fbthrift/thrift/lib/py"
+                        )
+                    ),
+                    builder.run(
+                        ShellQuoted(
+                            "sudo python setup.py install"
+                        )
+                    ),
+                ]
+            ),
+        ],
+    }

--- a/build/debian_system_builder/debian_specs/python_fbzmq.py
+++ b/build/debian_system_builder/debian_specs/python_fbzmq.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# Copyright (c) Facebook, Inc. and its affiliates.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import debian_specs.fbzmq as fbzmq
+
+from shell_quoting import ShellQuoted, path_join
+
+
+def fbcode_builder_spec(builder):
+    return {
+        'depends_on': [fbzmq],
+        'steps': [
+            builder.step(
+                "Install fbzmq python modules",
+                [
+                    builder.workdir(
+                        path_join(
+                            builder.option('projects_dir'),
+                            "fbzmq/fbzmq/py"
+                        )
+                    ),
+                    builder.run(
+                        ShellQuoted(
+                            "sudo python setup.py install"
+                        )
+                    ),
+                ]
+            ),
+        ],
+    }

--- a/build/debian_system_builder/debian_system_builder.py
+++ b/build/debian_system_builder/debian_system_builder.py
@@ -96,9 +96,12 @@ class DebianSystemFBCodeBuilder(ShellFBCodeBuilder):
         return self.step('Check out {0}, workdir {1}'.format(project, path), [
             self.workdir(base_dir),
             self.run(
-                ShellQuoted('if [[ ! -e "{p}" ]]; then \n'
+                ShellQuoted('if [[ ! -d {d} ]]; then \n'
                             '\tgit clone https://github.com/{p}\n'
-                            'fi').format(p=project)
+                            'fi').format(p=project,
+                                         d=path_join(base_dir,
+                                                     os.path.basename(project))
+                                        )
             ) if not local_repo_dir else self.copy_local_repo(
                 local_repo_dir, os.path.basename(project)
             ),

--- a/build/debian_system_builder/debian_system_builder.py
+++ b/build/debian_system_builder/debian_system_builder.py
@@ -118,6 +118,14 @@ class DebianSystemFBCodeBuilder(ShellFBCodeBuilder):
             self.run(ShellQuoted('sudo ldconfig')),
         ]
 
+    def debian_deps(self):
+        return super(DebianSystemFBCodeBuilder, self).debian_deps() +\
+            [
+                'python-setuptools',
+                'python3-setuptools',
+                'python-pip',
+            ]
+
     def setup(self):
         steps = [
             ShellQuoted('#!/bin/bash\n'),


### PR DESCRIPTION
Description:
- Skipping project cloning for existing projects is broken due to wrong project names in the build script
- Breeze and its dependencies are not installed by the build script 

This PR:
1. Fixes the project cloning bug by changing the project names in the conditionals
2. Enhances the debian-system-builder to install the required python modules

Test Plan:
1. Go to build directory: `cd build`
2. Run the debian-system-builder to create buildscript:
    ```
    python debian_system_builder/debian_system_builder.py > ./build_openr.sh
    ```