### PR TITLE
[fbcode_builder] Fix shell builders

### DIFF
--- a/build/debian_system_builder/debian_system_builder.py
+++ b/build/debian_system_builder/debian_system_builder.py
@@ -192,9 +192,8 @@ if __name__ == "__main__":
         os.path.dirname(__file__), "debian_system_fbcode_builder_config.py"
     )
     config = read_fbcode_builder_config(config_file)
-    builder = DebianSystemFBCodeBuilder()
+    builder = DebianSystemFBCodeBuilder(projects_dir=projects_dir)
 
-    builder.add_option("projects_dir", projects_dir)
     if distutils.spawn.find_executable("ccache"):
         ccache_dir = ccache_dir()
         builder.add_option("ccache_dir", ccache_dir)

--- a/build/fbcode_builder/shell_builder.py
+++ b/build/fbcode_builder/shell_builder.py
@@ -99,9 +99,8 @@ if __name__ == '__main__':
     temp = persistent_temp_dir(repo_root)
 
     config = read_fbcode_builder_config('fbcode_builder_config.py')
-    builder = ShellFBCodeBuilder()
+    builder = ShellFBCodeBuilder(projects_dir=temp)
 
-    builder.add_option('projects_dir', temp)
     if distutils.spawn.find_executable('ccache'):
         builder.add_option('ccache_dir',
             os.environ.get('CCACHE_DIR', os.path.join(temp, '.ccache')))


### PR DESCRIPTION
In 0ae204a978c11ddefafd81bd319a078239a44c1c the 'projects_dir' option
became a required constructor argument since it is called within the
constructor. However, it has not been adjusted in the subclasses that
used to set the option after instantiation. This commit fixes the
'shell_builder' and the 'debian_system_builder'.

Test Plan:
1. Go to build directory: `cd build`
2. Run the `shell_builder` & `debian_system_builder`:
    - `python fbcode_builder/shell_builder.py`
    - `python debian_system_builder/debian_system_builder.py`

`shell_builder` output before:
```
Traceback (most recent call last):
  File "fbcode_builder/shell_builder.py", line 102, in <module>
    builder = ShellFBCodeBuilder()
  File "/home/butjar/tu/ma/openr/build/fbcode_builder/fbcode_builder.py", line 93, in __init__
    self._github_dir = self.option('projects_dir')
  File "/home/butjar/tu/ma/openr/build/fbcode_builder/fbcode_builder.py", line 108, in option
    raise RuntimeError('Option {0} is required'.format(name))
RuntimeError: Option projects_dir is required
```

`shell_builder` output after:
```
set -exo pipefail
export CCACHE_DIR='/home/butjar/.fbcode_builder-sZshomesZsbutjarsZstusZsmasZsopenr/.ccache' CC="ccache ${CC:-gcc}" CXX="ccache ${CXX:-g++}"
### Diagnostics ###

# Builder ShellFBCodeBuilder(google/googletest:cmake_defines={u'BUILD_GTEST': u'ON', u'BUILD_SHARED_LIBS': u'OFF'}, google/googletest:git_hash=u'release-1.8.1', facebook/openr:local_repo_dir='/home/butjar/tu/ma/openr', facebook/zstd:git_hash=ShellQuoted(u'$(git describe --abbrev=0 --tags origin/master)'), openr/build:cmake_defines={u'ADD_ROOT_TESTS': u'OFF'}, thom311/libnl:git_hash=u'libnl3_2_25', projects_dir=u'/home/butjar/.fbcode_builder-sZshomesZsbutjarsZstusZsmasZsopenr', fmtlib/fmt:git_hash=u'5.3.0', wangle/wangle/build:cmake_defines={u'BUILD_TESTS': u'OFF'}, prefix=u'/home/butjar/.fbcode_builder-sZshomesZsbutjarsZstusZsmasZsopenr/installed', fizz/fizz/build:cmake_defines={u'BUILD_TESTS': u'ON'}, ccache_dir=u'/home/butjar/.fbcode_builder-sZshomesZsbutjarsZstusZsmasZsopenr/.ccache', zeromq/libzmq:git_hash=u'v4.2.2', make_parallelism=4, jedisct1/libsodium:git_hash=u'stable')
hostname
cat /etc/issue || echo no /etc/issue
g++ --version || echo g++ not installed
cmake --version || echo cmake not installed

### Check out fmtlib/fmt, workdir build ###

mkdir -p '/home/butjar/.fbcode_builder-sZshomesZsbutjarsZstusZsmasZsopenr' && cd '/home/butjar/.fbcode_builder-sZshomesZsbutjarsZstusZsmasZsopenr'
git clone  https://github.com/'fmtlib/fmt'
mkdir -p '/home/butjar/.fbcode_builder-sZshomesZsbutjarsZstusZsmasZsopenr'/'fmt'/'build' && cd '/home/butjar/.fbcode_builder-sZshomesZsbutjarsZstusZsmasZsopenr'/'fmt'/'build'
git checkout '5.3.0'

### Build and install fmtlib/fmt ###

...
```