### PR TITLE
[fbcode_builder] Fix shebang in shell_builder

### DIFF
--- a/build/fbcode_builder/shell_builder.py
+++ b/build/fbcode_builder/shell_builder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env )python
+#!/usr/bin/env python
 # Copyright (c) Facebook, Inc. and its affiliates.
 from __future__ import absolute_import
 from __future__ import division


### PR DESCRIPTION
Typo in python shebang introduced by 0d19e27, probably by accident.

Found while skimming the code.