### PR TITLE
[fbcode_builder] Update libzmq package name

### DIFF
--- a/build/fbcode_builder/manifests/libzmq
+++ b/build/fbcode_builder/manifests/libzmq
@@ -6,7 +6,7 @@ zeromq-devel
 zeromq
 
 [debs]
-libzmq-dev
+libzmq3-dev
 
 [download]
 url = https://github.com/zeromq/libzmq/releases/download/v4.3.1/zeromq-4.3.1.tar.gz


### PR DESCRIPTION
Since Ubuntu 17.04 `libzmq-dev` is no longer available. Install
`libzmq3-dev` instead.

See: https://github.com/SciRuby/iruby/issues/131

Test Plan:
- Check github workflow output

This is not a really clean solution, since there should be a conditional checking the Ubuntu version, or something comparable. However, since the github workflow is configured for Ubuntu 18.04 this solution should be an improvement.
Note: I was not able to get a complete successful workflow build. My fork gets stuck when building the dependencies, but with this fix the workflow passes the `Install system deps` stage again. It's hard to debug further without access to the CMake logs.