### PR TITLE
[debian system builder] Compile with gcc7

### DIFF
--- a/build/debian_system_builder/debian_system_builder.py
+++ b/build/debian_system_builder/debian_system_builder.py
@@ -178,7 +178,7 @@ def ccache_dir():
 def gcc_version():
     gcc_version = os.environ.get("GCC_VERSION")
     if not gcc_version:
-        gcc_version = "5"
+        gcc_version = "7"
     return gcc_version
 
 


### PR DESCRIPTION
The build script that is generated by `debian_system_builder` currently
compiles OpenR and the dependencies with gcc5. It seems that at least
some of the dependencies require at least gcc7. Update the
`debian_system_builder` to use gcc7 by default.