### PR TITLE
Add Docs Sphinx Support

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,33 @@
+name: Documentation Build
+
+on:
+  push:
+    paths:
+      - "openr/docs/**"
+      - "README.md"
+      - "CONTRIBUTING.md"
+  pull_request:
+    paths:
+      - "openr/docs/**"
+      - "README.md"
+      - "CONTRIBUTING.md"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r "openr/docs/requirements.txt"
+
+      - name: Build documentation
+        run: make -C openr/docs html

--- a/openr/docs/.gitignore
+++ b/openr/docs/.gitignore
@@ -1,1 +1,2 @@
+build/
 *.html

--- a/openr/docs/Developer_Guide/DeveloperGuide.md
+++ b/openr/docs/Developer_Guide/DeveloperGuide.md
@@ -1,5 +1,4 @@
-`DeveloperGuide`
-----------------
+# Developer Guide
 
 If you are actively using OpenR and interested in contributing back then we,
 the OpenR team at Facebook, are happy to help you get started. Here are some

--- a/openr/docs/Features/index.rst
+++ b/openr/docs/Features/index.rst
@@ -1,0 +1,19 @@
+Features
+==================================
+
+Here we explain in detail all the features of Open/R.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents:
+
+   RibPolicy
+   SourceRouting
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/openr/docs/Introduction/Overview.md
+++ b/openr/docs/Introduction/Overview.md
@@ -1,13 +1,12 @@
-`OpenR`
--------
+# Introduction to Open Routing
 
 Open Routing, OpenR, is Facebook's internally designed and developed routing
-protocol/platform. Primarily built for performing routing in the `Terragraph`
-network, it's awesome design and flexibility has led to its adoption in
-Facebook's WAN Network, `Express Backbone`, as the sole IGP routing protocol.
+protocol/platform. Primarily built for performing routing in the 
+[Terragraph](https://terragraph.com/) network, it's design and flexibility has 
+led to its adoption in Facebook's DC and
+WAN Network, `Express Backbone`, as the sole IGP routing protocol.
 
 ### Goals
----
 
 It all started with the original goal of building a simple and extensible routing
 protocol for the Terragraph project and beyond.
@@ -33,7 +32,6 @@ extensibility helps a lot. We are driven primarily by the idea of autonomic
 networking and the ability to innovate quickly.
 
 ### Why another protocol ?
----
 
 Our intent is not building a new protocol, but rather provide a modular solution
 to build distributed applications in the network of any kind (wireless mesh,
@@ -52,7 +50,6 @@ and tuned appropriately. In addition, we are looking to build upon the concepts
 of autonomic networking and make our networks easier to configure and manage.
 
 ### Routing Protocol Design
----
 
 The protocol implementation consists of the components depicted below:
 * `KvStore` - Key Value Store
@@ -73,76 +70,13 @@ for each module and you can read more about other modules in it's own section.
 
 
 ### Code Organization
----
 
 The code is very modularized and each module is self-contained. For more information
 about each module please refer to documentation in header files of that module.
 The code is very well documented. This README gives you an overview of how different
 modules/libraries come together to build OpenR.
 
-### Documentation
----
-
-High-level overview of the documentation organization (alphabetically ordered)
-
-#### [`Breeze.md`](Breeze.md)
-
-Python click based CLI tool to interact with OpenR
-
-#### [`Decision.md`](Decision.md)
-
-Detailed overview about `openr/decision` module
-
-#### [`DeveloperGuide.md`](DeveloperGuide.md)
-
-Instructions on how to contribute to `OpenR` project and follow best
-testing/coding practices.
-
-#### [`Fib.md`](Fib.md)
-
-Detailed overview about `openr/fib` module
-
-#### [`KvStore.md`](KvStore.md)
-
-Detailed overview about eventually replicated datastore, `openr/kvstore` and
-it's operations as well as features.
-
-#### [`LinkMonitor.md`](LinkMonitor.md)
-
-Detailed overview about `openr/link-monitor` module
-
-#### [`Miscellaneous.md`](Miscellaneous.md)
-
-Miscellaneous notes and references e.g. various `OpenR` features like v4,
-parallel links, drain and graceful restart, security concerns, marking control
-plane packets and potential extensions.
-
-#### [`Monitoring.md`](Monitoring.md)
-
-A detailed overview of monitoring operations of OpenR. e.g. syslog, special
-event logs (structured) and counters.
-
-#### [`Platform.md`](Platform.md)
-
-Guide for integrating OpenR on a new platform and overview about `openr/platform`
-codebase.
-
-#### [`PrefixManager.md`](PrefixManager.md)
-
-Managing prefix information in KvStore.
-
-#### [`Runbook.md`](Runbook.md)
-
-Documentation explaining in detail how to run and configure OpenR along with
-all supported configuration options
-
-#### [`Spark.md`](Spark.md)
-
-Neighbor discovery protocol of OpenR .... a simpler and extensible version
-of the well-documented `bfd` protocol.
-
 ### Roadmap
----
 
 Open/R is evolving rapidly and we expect to add several features in the short term
 to handle network routing requirements. The current list of features we have on our
@@ -154,7 +88,6 @@ mind is
 
 
 ### Releases
----
 
 Things move fast at Facebook which means our internal release cycle for a new
 rollout of OpenR is on the order of weeks. You will see weekly tags (`2017-11-15`)
@@ -166,7 +99,6 @@ In the future, our release plan might change and we might tag some stable releas
 but until then we will just have weekly tags.
 
 ### Extra Readings
----
 - [0MQ Internal Architecture](http://zeromq.org/whitepapers:architecture)
 - [Terragraph](https://code.facebook.com/posts/1072680049445290/introducing-facebook-s-new-terrestrial-connectivity-systems-terragraph-and-project-aries/)
 - [Express Backbone](https://code.facebook.com/posts/1782709872057497/building-express-backbone-facebook-s-new-long-haul-network/)

--- a/openr/docs/Makefile
+++ b/openr/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/openr/docs/Operator_Guide/RouteRepresentation.md
+++ b/openr/docs/Operator_Guide/RouteRepresentation.md
@@ -1,5 +1,4 @@
-`Route Representation`
-----------------------
+# Route Representation
 
 Open/R provides flexible ways of expressing reachability information. It allows
 a network operator to express `Preference`, `Performance`, and `Policy Metadata`
@@ -7,7 +6,6 @@ with every route announcement. This document describes the route representation
 in detail.
 
 ### Design Rationale
----
 
 Simplicity and flexibility are the two main criteria that we considered into the
 design of Open/R route. Traditional protocols like BGP, OSPF, and ISIS influenced
@@ -20,7 +18,6 @@ the design. The key takeaways
 - Path tracing
 
 ### Definitions
----
 
 #### `transitive`
 Attributes that are preserved during route re-distribution at Area Border. Note
@@ -32,7 +29,6 @@ The route attribute that can be altered by the policy during route re-distributi
 at Area Border. `immutable` is the opposite of `mutable`.
 
 ### Attributes
----
 
 #### > `prefix`
 `transitive`, `immutable`
@@ -67,7 +63,7 @@ incremented by `igp_cost` of the route within the area during route re-distribut
 across area. Should never decrease if manipulated via policy to ensure loop-free
 routing. This resembles AS-Path length of BGP
 
-> Take a look at [Decision Route Computation](Decision.md) for understanding best
+> Take a look at [Decision Route Computation](../Protocol_Guide/Decision.md) for understanding best
 route selection process
 
 #### > `tags`
@@ -118,6 +114,5 @@ node advertising this route. This is only compatible with forwarding type
 
 
 ### Thrift Struct
----
 
-Refer to [struct PrefixEntry in openr/if/Lsdb.thrift](../if/Lsdb.thrift)
+Refer to [struct PrefixEntry in openr/if/Lsdb.thrift](https://github.com/facebook/openr/blob/master/openr/if/Lsdb.thrift)

--- a/openr/docs/Operator_Guide/index.rst
+++ b/openr/docs/Operator_Guide/index.rst
@@ -1,0 +1,22 @@
+Operator Guide
+==================================
+
+Here we explain operating and managing Open Routing
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents:
+
+   CLI
+   Monitoring
+   RouteRepresentation
+   Runbook
+   Versions
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/openr/docs/Protocol_Guide/index.rst
+++ b/openr/docs/Protocol_Guide/index.rst
@@ -1,0 +1,27 @@
+Protocol Guide
+==================================
+
+Here we explain in detail all components and protocols used within Open Routing
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents:
+
+   Spark
+   KvStore
+   LinkMonitor
+   Decision
+   Platform
+   Fib
+   RangeAllocator
+   PrefixAllocator
+   PrefixManager
+   Miscellaneous
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/openr/docs/conf.py
+++ b/openr/docs/conf.py
@@ -1,0 +1,53 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Open/R'
+copyright = '2020, Facebook Inc.'
+author = 'Facebook Inc.'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'recommonmark',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/openr/docs/index.rst
+++ b/openr/docs/index.rst
@@ -1,0 +1,28 @@
+.. Open/R documentation master file, created by
+   sphinx-quickstart on Thu Oct 29 14:04:38 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Open/R's documentation!
+==================================
+
+Open Routing, OpenR, is Facebook's internally designed and developed routing protocol/platform.
+Open Routing in a component based Link State Interior Gateway Protocol that is very extendible
+and customizable. It is used in Facebook's Datacenters, Backbone and Wireless Mesh products.
+
+.. toctree::
+   :maxdepth: 0
+   :caption: Contents:
+
+   Introduction/Overview
+   Protocol_Guide/index
+   Features/index
+   Operator_Guide/index
+   Developer_Guide/DeveloperGuide
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/openr/docs/make.bat
+++ b/openr/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/openr/docs/requirements.txt
+++ b/openr/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+recommonmark


### PR DESCRIPTION
Summary:
- Add ability to build Open Source documents for OpenR
- This is needed for read the docs support

Test Plan:
- manual: `make html` in `openr/docs` directory
- Add a GitHub Action to ensure we stay building
