### PR TITLE
Fix main link/lint errors

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -29,5 +29,8 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install -r "openr/docs/requirements.txt"
 
+      - name: Check all links resolve
+        run: make -C openr/docs linkcheck
+
       - name: Build documentation
         run: make -C openr/docs html

--- a/openr/docs/Features/RibPolicy.md
+++ b/openr/docs/Features/RibPolicy.md
@@ -1,5 +1,4 @@
-`RIB Policy`
-------------
+# RIB Policy
 
 Routing Information Base (RIB) Policy provides ability to police the computed
 routes before programming in underlying hardware. Currently supported use-case
@@ -8,15 +7,17 @@ in future to support changing `admin-distance` (aka route priority), add or drop
 next-hops, change route metric, and block route from programming or
 re-distribution.
 
-### Flow Diagram
+## Flow Diagram
+
 ---
 
 `Decision` module in Open/R implements the RIB Policy processing. The RIB Policy
 applied on computed routes just before they're sent off for programming.
 
-<img src="https://user-images.githubusercontent.com/1482609/84713146-3f5b0c80-af1f-11ea-8d6b-58d7ce7a6a90.png" alt="RIB Policy Flow Diagram" width="whatever" height="400">
+![Decision Flow](https://user-images.githubusercontent.com/1482609/84713146-3f5b0c80-af1f-11ea-8d6b-58d7ce7a6a90.png)
 
-### Creating RIB Policy
+## Creating RIB Policy
+
 ---
 
 RIB Policy is expressed in thrift specification and is defined as `struct RibPolicy`
@@ -30,7 +31,8 @@ One such pair of Match-Action is termed as `RibPolicyStatement`. Multiple
 such statements can be specified. However, note that only first matching action
 will be applied.
 
-### Setting RIB Policy
+## Setting RIB Policy
+
 ---
 
 RIB Policy can be set via RPC API (aka thrift API). It is not supported to be
@@ -39,7 +41,7 @@ RibPolicy. It is important to note that policy have `ttl_secs` field which
 specifies the validity of policy, beyond which it is expired and effects of
 policy will be reverted.
 
-```
+```c++
 // Set policy API
 void setRibPolicy(1: RibPolicy ribPolicy) throws (1: OpenrError error)
 
@@ -47,11 +49,12 @@ void setRibPolicy(1: RibPolicy ribPolicy) throws (1: OpenrError error)
 RibPolicy getRibPolicy() throws (1: OpenrError error)
 ```
 
-[SetRibPolicy](`https://github.com/facebook/openr/tree/master/examples/SetRibPolicyExample.cpp`) example code is provided for reference in terms of how to define and set RibPolicy.
+[SetRibPolicy](https://github.com/facebook/openr/blob/master/examples/SetRibPolicyExample.cpp) example code is provided for reference in terms of how to define and set RibPolicy.
 
 For more details refer to `OpenrCtrl` service interface in [`OpenrCtrl.thrift`](https://github.com/facebook/openr/blob/master/openr/if/OpenrCtrl.thrift).
 
-### UseCase - NextHop Weight Transformation (UCMP)
+## UseCase - NextHop Weight Transformation (UCMP)
+
 ---
 
 Define and achieve policy driven weigted distribution of flows over multiple
@@ -71,6 +74,7 @@ will be removed. If policed route have no next-hop then it will be removed from
 RIB. This won't be programmed as well won't get re-distributed across the areas.
 
 ### Configuration Knob
+
 ---
 
 RibPolicy is by default disabled and RPC APIs will throw exception if an
@@ -79,11 +83,12 @@ this feature where it is not needed. You'll need to set the `enable_rib_policy`
 field in OpenrConfig to `true` to make use of RibPolicy feature.
 
 ### CLI
+
 ---
 
 Breeze CLI provides a command to view the currently configured RibPolicy.
 
-```
+```console
 $ breeze decision rib-policy
 > RibPolicy
   Validity: 291s

--- a/openr/docs/Features/SourceRouting.md
+++ b/openr/docs/Features/SourceRouting.md
@@ -1,8 +1,7 @@
-`Source Routing (SR)`
---------------------------
-
+# Source Routing (SR)
 
 ## Introduction
+
 ---
 
 Source Routing is a forwarding mechanism in a network where a path for the packet
@@ -25,6 +24,7 @@ At the last hop, all segments should've been dropped added by this network and
 network will be forwarded as per its destination address.
 
 ### Segments
+
 ---
 
 A Segment is an instruction that expresses the forwarding intent of the packet.
@@ -36,15 +36,18 @@ and `Local`. The scope determines the set of nodes that can understand and forwa
 the packet as per the associated segment.
 
 #### Scope - Local
+
 The segment's instruction can only be processed by the node that originates or
 own the segment. The local segment may have undesirable behavior on the other
 nodes.
 
 #### Scope - Area
+
 The segment instruction is well understood by all nodes within the area. Every
 node can process and forward the packet associated with this segment.
 
 #### Node Segment (Node SID)
+
 Node Segment is a unique segment associated with every node in an area. The scope
 of this segment is the `Area`.
 
@@ -59,6 +62,7 @@ saving one extra cycle of lookup on LER. Open/R performs PHP by default for Node
 Segment.
 
 #### Adjacency Segment (Adj SID)
+
 Adjacency Segment is a unique segment associated with every Open/R adjacency.
 The scope of this segment is `Local`.
 
@@ -66,6 +70,7 @@ Adjacency Segment forwards the network packets towards the associated adjacency
 and pops the segment before doing so.
 
 ### Data Plane
+
 ---
 
 Segment Routing is a concept and realizing its actual behavior can be achieved
@@ -81,21 +86,25 @@ leveraged to encode segment information. Each segment is an IPv6 address and
 incurs 16-byte of overhead. [Read more](https://tools.ietf.org/html/rfc8754)
 
 In Open/R we chose MPLS as data-plane for forwarding mechanism for two reasons
+
 - Widely adopted and supported by network hardware
 - Incurs less overhead on the packet
 
 ### MPLS Segment Operations
+
 ---
 
 There are 3 types of operations a network device needs to support to segment
 routing with MPLS
 
 #### Push
+
 Add one or more labels on the top of the incoming packet (determined by FEC)
 with egress instruction (nexthop/interface). This operation often happens on LER
 when packet enters into SR enabled network.
 
 #### Continue
+
 Swapping the incoming label with one or more outgoing label(s) along with egress
 instruction (next-hop/interface). This operation is often carried out to retain
 label or swap label when packet is transitioning within SR enabled network.
@@ -105,55 +114,64 @@ swap an incoming label with an outgoing label-stack with an egress instruction
 (i.e., binding SID).
 
 #### Next
+
 Popping the topmost label. Often carried out when the packet reaches or will
 reach in immediate next-hop to the destination indicated by the topmost label.
 
 ### Configuration
+
 ---
 
 #### Enabling Segment Routing
-Configuration Knob in [OpenrConfig.thrift](../if/OpenrConfig.thrift#L211)
-```
+
+Configuration Knob in [OpenrConfig.thrift](https://github.com/facebook/openr/blob/master/openr/if/OpenrConfig.thrift)
+
+```thrift
   13: optional bool enable_segment_routing
 ```
 
 #### Configuring the Label Ranges
+
 There are two ranges statically defined in the code as constants for Area and
 Local segment scopes.
 
-```
+```console
 Area Range: [101, 49999]
 Local Range: [50000, 59999]
 ```
 
 #### Enabling IP->MPLS
+
 Every route advertisement in Open/R allows the specification of forwarding
 type. Setting this to `SR_MPLS` via config will make all Label Edge Routers (LER)
 to programm `IP to MPLS` route for all advertisement from the node advertising
 IP prefixes. The advertised prefix will assume the node label (aka Prefix SID).
 This works with anycast prefixes as well.
 
-Configuration for Forwarding Type [OpenrConfig.thrift](if/OpenrConfig.thrift#L210)
-```
+Configuration for Forwarding Type [OpenrConfig.thrift](https://github.com/facebook/openr/blob/master/openr/if/OpenrConfig.thrift)
+
+```thrift
     12: PrefixForwardingAlgorithm prefix_forwarding_algorithm,
 ```
 
 ### Label Allocation
+
 ---
 
 There are two label types that Open/R will perform per node. A node-label which
 is unique within a whole network and per node adjacency-label which is unique
 within the node and has local significance only.
 
-* NodeSID will take node-label
-* AdjacencySID will take adjacency-label
+- NodeSID will take node-label
+- AdjacencySID will take adjacency-label
 
 Open/R  supports allocating unique label/integer per node (LDP function). It is
 implemented as a distributed computing enabled by KvStore. Also each adjacency
 is assigned unique label on a node, usually derived from interface index.
 
 You can look at the labels by inspecting adjacencies
-```
+
+```console
 [root@node1 ~]$ breeze kvstore adj
 
 > node1 => Version: 54, *Node Label: 21890*
@@ -163,20 +181,21 @@ node33    if_1_33_1   if_33_1_1    1       *50007*  169.254.0.5  fe80::6821:64ff
 ```
 
 ### MPLS Programming APIs
+
 ---
 
 Open/R will compute MPLS routes as per the Segment Routing architecture. This
-will need to be programmed in HW. The [Platform](Platform.md) will need to provide
+will need to be programmed in HW. The [Platform](../Protocol_Guide/Platform.md) will need to provide
 implementation for programming these routes in HW. Open/R provides the
 implementation for programming these routes in MPLS enabled Linux kernel.
 
 ### References
----
-* [Segment Routing Architecture](https://tools.ietf.org/html/rfc8402)
-* [Multiprotocol Label Switching Architecture](https://tools.ietf.org/html/rfc3031)
-* [IPv6 Segment Routing Header (SRH)](https://tools.ietf.org/html/rfc8754)
-* [Segment Routing with the MPLS Data Plane](https://tools.ietf.org/html/rfc8660)
-* [Intro to Segment Routing](https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/seg_routing/configuration/xe-3s/segrt-xe-3s-book/intro-seg-routing.pdf)
-* [Segment Routing in Linux Kernel](http://www.segment-routing.net/open-software/linux/)
-* [MPLS Tutorial for Linux](https://netdevconf.info/1.1/proceedings/slides/prabhu-mpls-tutorial.pdf)
-* [MPLS in GRE Tunnel on Linux](https://jsteward.moe/mpls-in-gre-tunnel-linux.html)
+
+- [Segment Routing Architecture](https://tools.ietf.org/html/rfc8402)
+- [Multiprotocol Label Switching Architecture](https://tools.ietf.org/html/rfc3031)
+- [IPv6 Segment Routing Header (SRH)](https://tools.ietf.org/html/rfc8754)
+- [Segment Routing with the MPLS Data Plane](https://tools.ietf.org/html/rfc8660)
+- [Intro to Segment Routing](https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/seg_routing/configuration/xe-3s/segrt-xe-3s-book/intro-seg-routing.pdf)
+- [Segment Routing in Linux Kernel](http://www.segment-routing.net/open-software/linux/)
+- [MPLS Tutorial for Linux](https://netdevconf.info/1.1/proceedings/slides/prabhu-mpls-tutorial.pdf)
+- [MPLS in GRE Tunnel on Linux](https://jsteward.moe/mpls-in-gre-tunnel-linux.html)

--- a/openr/docs/Introduction/Overview.md
+++ b/openr/docs/Introduction/Overview.md
@@ -68,7 +68,6 @@ protocols we do not focus on the wire format or interaction logic - rather, this
 is relegated to Thrift and ZMQ to deal with. Here is the high level of overview
 for each module and you can read more about other modules in it's own section.
 
-
 ### Code Organization
 
 The code is very modularized and each module is self-contained. For more information
@@ -81,11 +80,11 @@ modules/libraries come together to build OpenR.
 Open/R is evolving rapidly and we expect to add several features in the short term
 to handle network routing requirements. The current list of features we have on our
 mind is
-- Encryption and authentication for control plane communication
-- Segment Routing
-- Emulation - Testing framework
-- Weighted ECMP routing
 
+* Encryption and authentication for control plane communication
+* Segment Routing
+* Emulation - Testing framework
+* Weighted ECMP routing
 
 ### Releases
 
@@ -99,6 +98,6 @@ In the future, our release plan might change and we might tag some stable releas
 but until then we will just have weekly tags.
 
 ### Extra Readings
-- [0MQ Internal Architecture](http://zeromq.org/whitepapers:architecture)
-- [Terragraph](https://code.facebook.com/posts/1072680049445290/introducing-facebook-s-new-terrestrial-connectivity-systems-terragraph-and-project-aries/)
-- [Express Backbone](https://code.facebook.com/posts/1782709872057497/building-express-backbone-facebook-s-new-long-haul-network/)
+
+* [Terragraph](https://engineering.fb.com/2016/04/13/connectivity/introducing-facebook-s-new-terrestrial-connectivity-systems-terragraph-and-project-aries/)
+* [Express Backbone](https://engineering.fb.com/2017/05/01/data-center-engineering/building-express-backbone-facebook-s-new-long-haul-network/)

--- a/openr/docs/Operator_Guide/Versions.md
+++ b/openr/docs/Operator_Guide/Versions.md
@@ -19,7 +19,7 @@ of `day`. Samples are:
 - version: `20200825`
 - lowestSupportedVersion: `20200214`
 
-See [docs/Spark.md](https://github.com/facebook/openr/blob/master/openr/docs/Spark.md)
+See [Spark.md](../Protocol_Guide/Spark.md)
 for more details about neighbor discivery mechanism inside `Spark`.
 
 ### Backward Compatibility

--- a/openr/docs/Protocol_Guide/Decision.md
+++ b/openr/docs/Protocol_Guide/Decision.md
@@ -1,5 +1,4 @@
-`Decision`
-----------
+# Decision
 
 Computes the routing table (IPv4, IPv6, MPLS). Uses Topology and Reachability
 information received from KvStore in the computation. Outputs RIB, aka
@@ -88,7 +87,7 @@ Computed label routes leverage Penultimate Hop Popping (PHP) for pop & forward
 instruction to avoid duplicate lookup of a packet when it reaches the
 destination.
 
-For more details refer to [Source Routing in Open/R](SourceRouting.md)
+For more details refer to [Source Routing in Open/R](../Features/SourceRouting.md)
 
 ### Route Notifications
 ---

--- a/openr/docs/Protocol_Guide/Fib.md
+++ b/openr/docs/Protocol_Guide/Fib.md
@@ -1,5 +1,4 @@
-`Fib`
------
+# Fib
 
 This module is responsible for programming the actual forwarding tables (e.g. in
 hardware) on the local node.

--- a/openr/docs/Protocol_Guide/KvStore.md
+++ b/openr/docs/Protocol_Guide/KvStore.md
@@ -1,5 +1,4 @@
-`KvStore - Store and Sync`
---------------------------
+# KvStore - Store and Sync
 
 `KvStore` provides a self-contained, in-memory `key-value` datastore which is
 eventually consistent. Underlying implementation is based on  **conflict-free

--- a/openr/docs/Protocol_Guide/LinkMonitor.md
+++ b/openr/docs/Protocol_Guide/LinkMonitor.md
@@ -1,5 +1,4 @@
-`LinkMonitor`
--------------
+# LinkMonitor
 
 This module is responsible for learning link information from the underlying
 system and managing neighbor sessions. At a high level it:

--- a/openr/docs/Protocol_Guide/Miscellaneous.md
+++ b/openr/docs/Protocol_Guide/Miscellaneous.md
@@ -1,5 +1,4 @@
-`Miscellaneous`
----------------
+# Miscellaneous
 
 ### OpenR and V4
 ---

--- a/openr/docs/Protocol_Guide/Platform.md
+++ b/openr/docs/Protocol_Guide/Platform.md
@@ -1,5 +1,4 @@
-# `Platform`
----
+# Platform
 
 Open/R relies on `Platform` layer to provide the service to program routes(
 i.e. Unicast Routes/MPLS Routes) on actual underneath system. `Platform`

--- a/openr/docs/Protocol_Guide/PrefixAllocator.md
+++ b/openr/docs/Protocol_Guide/PrefixAllocator.md
@@ -1,5 +1,4 @@
-`PrefixAllocator`
------------------
+# PrefixAllocator
 
 The class assigns each node with a unique prefix of a certain length from a
 given seed prefix in a distributed manner. It is built atop RangeAllocator.

--- a/openr/docs/Protocol_Guide/PrefixManager.md
+++ b/openr/docs/Protocol_Guide/PrefixManager.md
@@ -1,5 +1,4 @@
-`PrefixManager`
----------------
+# PrefixManager
 
 This module is responsible for keeping track of the prefixes originating
 from the node and advertising them into the network via KvStore.
@@ -85,5 +84,5 @@ Use thrift APIs defined in `openr/if/OpenrCtrl.thrift` for querying, adding,
 removing or updating originating prefixes.
 
 Additionally, you can add and remove prefixes from the `breeze` cli. See
-[docs/Breeze.md](https://github.com/facebook/openr/blob/master/openr/docs/Breeze.md)
+[CLI.md](../Operator_Guide/CLI.md)
 for more details

--- a/openr/docs/Protocol_Guide/RangeAllocator.md
+++ b/openr/docs/Protocol_Guide/RangeAllocator.md
@@ -1,5 +1,4 @@
-`RangeAllocator`
--------------
+# RangeAllocator
 
 RangeAllocator is an abstract module built on the top of `KvStore` communication
 channel to elect a unique integer value from a given range in a distributed

--- a/openr/docs/Protocol_Guide/Spark.md
+++ b/openr/docs/Protocol_Guide/Spark.md
@@ -1,5 +1,4 @@
-# `Spark`
----
+# Spark
 
 `Spark` is the neighbor discovery module of Open/R. It leverages IPv6 link-local
 multicast via UDP to discover and maintain Adjacencies, aka neighbor relationships.


### PR DESCRIPTION
- Fix all Links to other documents so `make linkcheck` passes
- Add to CI so we fail on any bad links add in the future
- Fix formatting + lints for Features subdir
- Fox all H1 of Protocol Guide

Test Plan:
- `make linkcheck`
- Add `make linkcheck` to CI run