### PR TITLE
Finish removing all `` H1s

### DIFF
--- a/openr/docs/Operator_Guide/CLI.md
+++ b/openr/docs/Operator_Guide/CLI.md
@@ -1,7 +1,8 @@
-`Breeze`
+# Open/R CLI: `breeze`
+
 --------
 
-`Breeze` is a `python-click` based CLI tool to peek into OpenR's state.
+`breeze` is a `python-click` based CLI tool to peek into OpenR's state.
 It allows you to inspect:
 
 - Link state database
@@ -13,8 +14,8 @@ It allows you to inspect:
 - Set/Unset overload bit for node and links or custom metrics on links
 - Add/Del/Modify keys in KvStore
 
-
 ### How it Works
+
 ---
 
 All OpenR modules expose various ZMQ APIs to access their internal state over
@@ -24,6 +25,7 @@ for each module which  Breeze leverages to talk to OpenR, retrieve
 information, and display it
 
 ### How to use it
+
 ---
 
 Breeze is very intuitive to use. Just do `--help` at any stage to see options,
@@ -33,7 +35,7 @@ command in detail.
 To get auto-completion in your bash shell, simply copy `eval
 "$(_BREEZE_COMPLETE=source breeze)"` to your `~/.bashrc`.
 
-```
+```console
 $ breeze
 Usage: breeze [OPTIONS] COMMAND [ARGS]...
 
@@ -56,12 +58,14 @@ Commands:
 ```
 
 ### KvStore Commands
+
 ---
 
 #### Nodes
+
 You can identify all nodes in a network based on the content of KvStore.
 
-```
+```console
 $ breeze kvstore nodes
 
 Node     V6-Loopback            V4-Loopback
@@ -73,6 +77,7 @@ Node     V6-Loopback            V4-Loopback
 ```
 
 #### Prefix/Adjacency Database
+
 Each node announces to the KvStore an Adjacency database, modeled as a list of
 neighbors, and a Prefix database, the list of prefixes announced from that node.
 Since every node has the same content in its KvStore (you can think of it as an
@@ -82,14 +87,14 @@ the network.
 By default `prefixes` and `adj` KvStore commands will show information for local
 node only unless specified with `--nodes=all` or `--nodes=<node1>,<node2>`.
 
-```
+```console
 //
 // See prefixes of a current node (node1)
 //
 
 $ breeze kvstore prefixes
 
-> node1's prefixes
+> node1 prefixes
 da00:cafe:babe:f6:f70b::/80
 fc00:cafe:babe::1/128
 192.168.0.1/32
@@ -100,7 +105,7 @@ fc00:cafe:babe::1/128
 
 $ breeze kvstore adj --nodes=node3
 
-> node3's adjacencies, version: 4, Node Label: 43049, Overloaded?: False
+> node3 adjacencies, version: 4, Node Label: 43049, Overloaded?: False
 Neighbor    Local Interface    Remote Interface      Metric    Weight    Adj Label  NextHop-v4    NextHop-v6                 Uptime
 node4       if_3_4_0           if_4_3_0                   1         1        50007  172.16.0.7    fe80::f498:41ff:fe0c:6c23  2m57s
 node1       if_3_1_0           if_1_3_0                   1         1        50006  172.16.0.2    fe80::90be:bbff:fe2b:d4f7  2m57s
@@ -119,7 +124,8 @@ More fun with KvStore. Read-write operations on replicated datastore via breeze
 CLI.
 
 - List keys in KvStore. Print all keys along with their TTL information.
-```
+
+```console
 $ breeze kvstore keys --ttl
 
 Key                   OriginatorId      Version  TTL (HH:MM:SS)      TTL Version
@@ -143,7 +149,8 @@ prefix:node4          node4                   4  0:05:00                       5
 ```
 
 - List specific key-values
-```
+
+```console
 $ breeze kvstore keyvals nodeLabel:1
 
 > nodeLabel:1 ---
@@ -151,7 +158,8 @@ $ breeze kvstore keyvals nodeLabel:1
 ```
 
 - Add some custom key
-```
+
+```console
 // Set key with 60 seconds validity
 $ breeze kvstore set-key test-key test-value --version=1 --ttl=60
 Success: Set key test-key with version 1 and ttl 60000 successfully in KvStore.
@@ -160,7 +168,8 @@ persisted back
 ```
 
 - Get the key we just set
-```
+
+```console
 $ breeze kvstore keys --prefix=test-key --ttl
 
 Key       OriginatorId      Version  TTL (HH:MM:SS)      TTL Version
@@ -173,7 +182,8 @@ $ breeze kvstore keyvals test-key
 ```
 
 - Override the old value with a new one with a higher version
-```
+
+```console
 $ breeze kvstore set-key test-key test-value --version=2 --ttl=60
 Success: Set key test-key with version 1 and ttl 60000 successfully in KvStore.
 This does not guarantee that value is updated in KvStore as old value can be
@@ -187,43 +197,45 @@ $ breeze kvstore keyvals test-key
 - Erase key from KvStore. It is performed by setting TTL of the key to zero.
 
 > NOTE: You shouldn't try to erase keys originated by OpenR
-
 > NOTE: Erase only happens on all nodes reachable from the current node. Any
 node momentarily disconnected from the network might bring back the key you just
 erased.
 
-```
+```console
 $ breeze kvstore erase-key test-key
 Success: key test-key will be erased soon from all KvStores.
 ```
 
 #### KvStore Compare
+
 Get the delta between contents of two KvStores. By default, the command will
 compare each pair of nodes in the network. It will output nothing if the
 kvstores are synced between nodes. There should be no difference if nodes are
 part of the same network.
 
-```
+```console
 $ breeze kvstore kv-compare --nodes='fc00:cafe:babe::3'
 dumped kv from fc00:cafe:babe::3
 ```
 
 #### KvStore Signature
+
 Returns a signature of the contents of the KV store for comparison with other
 nodes.  In case of a mismatch, use `kv-compare` to analyze differences.
 
-```
+```console
 $ breeze kvstore kv-signature
 sha256: d0bd6722917451be2f56a9b1e720ecffeb7e45f9c0e842d62dc90c1d047d870f
 ```
 
 #### Peers
+
 The KvStore of a node is connected to the KvStores of all immediate neighbors.
 All updates are flooded via PUB/SUB channels between these stores and they
 guarantee eventual consistency of data on all nodes. This command shows
 information about a node's KvStore peers and details of the connections.
 
-```
+```console
 $ breeze kvstore peers
 
 > node2
@@ -236,10 +248,10 @@ pub via tcp://[fe80::ecf4:d3ff:fef1:4cb6%if_1_3_0]:60001
 ```
 
 #### Snoop
+
 Live snooping on KV-store updates in the network.
 
-
-```
+```console
 $ breeze -H 2401:db00:2120:20ed:feed::1 kvstore snoop
 
 > Key: test-key update
@@ -257,43 +269,46 @@ version:  1  -->  2
 ```
 
 #### Visualize topology
+
 Generates an image file with a visualization of the topology. Use `scp` to copy
 it to your local machine to open the image file.
 
-```
+```console
 $ breeze kvstore topology
 Saving topology to file => /tmp/openr-topology.png
 ```
 
 ### Decision Commands
+
 ---
 
 #### Adjacency/Prefixes Database
+
 Dump the link-state and prefixes databases from Decision module.
 
-```
+```console
 $ breeze decision adj
 
-> node1's adjacencies, version: N/A, Node Label: 41983, Overloaded?: False
+> node1 adjacencies, version: N/A, Node Label: 41983, Overloaded?: False
 Neighbor    Local Interface    Remote Interface      Metric    Weight    Adj Label  NextHop-v4    NextHop-v6                 Uptime
 node2       if_1_2_0           if_2_1_0                   1         1        50006  172.16.0.1    fe80::e0fd:b7ff:fe23:e73f  1h37m
 node3       if_1_3_0           if_3_1_0                   1         1        50007  172.16.0.3    fe80::ecf4:d3ff:fef1:4cb6  1h37m
 
 $ breeze decision prefixes
 
-> node1's prefixes
+> node1 prefixes
 fc00:cafe:babe::1/128
 da00:cafe:babe:f6:f70b::/80
 192.168.0.1/32
 ```
 
-
 #### Path
+
 List all the paths from a source node to a destination node based on the
 link-state information in Decision module. Flag the paths that are actually
 programmed into Fib module with `*`.
 
-```
+```console
 $ breeze decision path --src=node1 --dst=node4
 2 paths are found.
 
@@ -308,9 +323,10 @@ $ breeze decision path --src=node1 --dst=node4
 ```
 
 #### Routes
+
 Request the computed routing table
 
-```
+```console
 $ breeze decision routes
 
 > 192.168.0.2/32
@@ -345,22 +361,25 @@ via fe80::ecf4:d3ff:fef1:4cb6@if_1_3_0 metric 2
 ```
 
 #### Validate
+
 Check all prefix & adj dbs in Decision against that in KvStore.
 
-```
+```console
 $ breeze decision validate
 Decision is in sync with KvStore if nothing shows up
 ```
 
 ### LinkMonitor Commands
+
 ---
 
 #### links
+
 OpenR discovers local interfaces of a node (based on specified regular
 expressions) and monitors their status via asynchronous Netlink APIs. It also
 performs neighbor discovery on learned links.
 
-```
+```console
 $ breeze lm links
 
 Interface    Status    Overloaded    Metric Override    ifIndex    Addresses
@@ -376,11 +395,12 @@ if_1_3_0     Up                                         7          172.16.0.2
 Set/unset custom metric value for a link.
 
 - Set custom link metric on one link and drain another link
+
 > NOTE: Setting link overload will make link completely unusable for routing
 while setting a high value as the link metric will make the link less
 preferable, mimicking hard-drain and soft-drain behavior respectively.
 
-```
+```console
 $ breeze lm set-link-metric if_1_2_0 5
 
 Are you sure to set override metric for interface if_1_2_0 ? [yn] y
@@ -392,7 +412,8 @@ Are you sure to set overload bit for interface aq_1_3_0 ? [yn] y
 ```
 
 - List links
-```
+
+```console
 $ breeze lm links
 
 Interface    Status    Overloaded    Metric Override    ifIndex    Addresses
@@ -405,7 +426,7 @@ if_1_3_0     Up        True                             7          172.16.0.2
 
 - Undo changes with unset operation
 
-```
+```console
 $ breeze lm unset-link-metric if_1_2_0
 
 Are you sure to unset override metric for interface if_1_2_0 ? [yn] y
@@ -422,7 +443,8 @@ Setting node overload will maintain reachability to/from this node but it will
 not use the node for transit traffic.
 
 - Set node overload
-```
+
+```console
 $ breeze lm set-node-overload
 
 Are you sure to set overload bit for node node1 ? [yn] y
@@ -430,17 +452,19 @@ Successfully set overload bit..
 ```
 
 - See that it is reflected in its adjacency DB
-```
+
+```console
 $ breeze kvstore adj
 
-> node1's adjacencies, version: 10, Node Label: 41983, Overloaded?: True
+> node1 adjacencies, version: 10, Node Label: 41983, Overloaded?: True
 Neighbor    Local Interface    Remote Interface      Metric    Weight    Adj Label  NextHop-v4    NextHop-v6                 Uptime
 node2       if_1_2_0           if_2_1_0                   1         1        50006  172.16.0.1    fe80::e0fd:b7ff:fe23:e73f  1h51m
 node3       if_1_3_0           if_3_1_0                   1         1        50007  172.16.0.3    fe80::ecf4:d3ff:fef1:4cb6  1h51m
 ```
 
 - Unset node overload
-```
+
+```console
 $ breeze lm unset-node-overload
 
 Are you sure to unset overload bit for node node1 ? [yn] y
@@ -453,9 +477,10 @@ PrefixManager exposes APIs to list, advertise and withdraw prefixes into the
 network for the current node.
 
 #### view
+
 List this node's currently advertised prefixes
 
-```
+```console
 $ breeze prefixmgr view
 
 Type              Prefix
@@ -469,19 +494,21 @@ PREFIX_ALLOCATOR  da00:cafe:babe:f6:f70b::/80
 
 - Advertise a prefix from this node.
 
-```
+```console
 $ breeze prefixmgr advertise face:b00c::/64
 Advertised face:b00c::/64
 ```
 
 - Sync routes with new list of routes of a given type (BREEZE here)
-```
+
+```console
 $ breeze prefixmgr sync face:b00c::/80
 Synced 1 prefixes with type BREEZE
 ```
 
 - List current node's prefix database
-```
+
+```console
 $ breeze prefixmgr view
 
 Type              Prefix
@@ -493,7 +520,8 @@ PREFIX_ALLOCATOR  da00:cafe:babe:f6:f70b::/80
 ```
 
 - Withdraw advertised routes
-```
+
+```console
 $ breeze prefixmgr withdraw face:b00c::/80
 Withdrew face:b00c::/80
 ```
@@ -502,6 +530,7 @@ Withdrew face:b00c::/80
 with the `--prefix-type` option
 
 ### Config Commands
+
 ---
 
 Config is stored as opaque key-values on the disk. Here are APIs to read and
@@ -510,7 +539,8 @@ update it.
 #### List configs of various modules
 
 - Dump link monitor config.
-```
+
+```console
 $ breeze config link-monitor
 == Link monitor parameters stored ==
 
@@ -525,7 +555,8 @@ $ breeze config link-monitor
 ```
 
 - Dump prefix allocation config.
-```
+
+```console
 $ breeze config prefix-allocator
 
 == Prefix Allocator parameters stored  ==
@@ -538,7 +569,8 @@ $ breeze config prefix-allocator
 ```
 
 - Dump prefix manager config.
-```
+
+```console
 $ breeze config prefix-manager
 
 == Prefix Manager parameters stored  ==
@@ -551,27 +583,29 @@ da00:cafe:babe:94:4634::/80
 #### Store/Erase configs manually (Not so useful commands)
 
 - Erase a config key.
-```
+
+```console
 $ breeze config erase prefix-manager-config
 Key erased
-
 ```
-
 
 - Store a config key.
-```
+
+```console
 $ breeze config store prefix-allocator-config /tmp/config
 Key stored
 ```
 
 ### Monitor Commands
+
 ---
 
 #### counters
+
 Fetch and display OpenR counters. You can programmatically fetch these counters
 periodically via Monitor client and export them for monitoring purposes.
 
-```
+```console
 $ breeze monitor counters --prefix decision
 
 decision.adj_db_update.count.0 : 16.0
@@ -597,6 +631,7 @@ decision.spf_runs.count.600 : 0.0
 ```
 
 ### FIB Commands
+
 ---
 
 FIB is the only platform-specific part of OpenR. FibAgent runs as a separate
@@ -604,13 +639,15 @@ service on the node which is primarily responsible for managing the routing
 tables on the node. Breeze also exposes commands to interact with FibAgent.
 
 #### List/Add/Delete route via breeze!
+
 > NOTE: You don't need to do this but they are just for fun!
 
 This command only shows how to `add/del` routes. You can instead use the `sync`
 command to replace all existing routing entries with newly specified routes.
 
 - List routes
-```
+
+```console
 $ breeze -H leb01.labdca1 fib list
 
 == leb01.labdca1's FIB routes ==
@@ -623,13 +660,14 @@ via fe80::21c:73ff:fe3c:e50c@Port-Channel1201
 ```
 
 - Add new route
-```
-// add route
+
+```console
+# add route
 $ breeze -H leb01.labdca1 fib add '192.168.0.0/32' '1.3.4.5@Port-Channel1201'
 192.168.0.0 32
 Added 1 routes.
 
-// list routes
+# list routes
 $ breeze -H leb01.labdca1 fib list
 
 == leb01.labdca1's FIB routes ==
@@ -645,8 +683,9 @@ via fe80::21c:73ff:fe3c:e50c@Port-Channel1201
 ```
 
 - Delete existing routes
-```
-// delete routes
+
+```console
+# delete routes
 $ breeze -H leb01.labdca1 fib del '192.168.0.0/32'
 192.168.0.0 32
 Deleted 1 routes.
@@ -664,10 +703,11 @@ via fe80::21c:73ff:fe3c:e50c@Port-Channel1201
 ```
 
 #### Syncing routes
+
 You can use sync API to synchronize routing table with fresh routing table
 entries.
 
-```
+```console
 $ breeze -H leb01.labdca1 fib list
 
 == leb01.labdca1's FIB routes ==
@@ -684,7 +724,6 @@ Reprogrammed FIB with 0 routes.
 $ breeze -H leb01.labdca1 fib list
 
 == leb01.labdca1's FIB routes ==
-
 ```
 
 #### `linux` for platforms where we use Linux routing
@@ -694,14 +733,15 @@ which validates if the system (kernel routing table) has all the routes that
 OpenR intended to program.  In case of a mismatch, the discrepancies will be
 reported to aid debugging.
 
-```
+```console
 $ breeze fib validate-linux
 PASS
 Fib and Kernel routing table match
 ```
 
 An example of reporting discrepancy
-```
+
+```console
 $ breeze fib validate-linux
 FAIL
 Fib and Kernel routing table do not match

--- a/openr/docs/Operator_Guide/Monitoring.md
+++ b/openr/docs/Operator_Guide/Monitoring.md
@@ -1,5 +1,4 @@
-`Monitoring`
-------------
+# Monitoring
 
 Each module internally generates its own list of counters using the `ThreadData`
 library (which has supports for stats like SUM/RATE/COUNT over various
@@ -13,8 +12,8 @@ Further, each module logs important events like `IFACE_UP` or `NEIGHBOR_DOWN`
 in a structured fashion via ZmqMonitor which can be logged to data stores
 like `Druid` to do real-time monitoring of log events across the fleet.
 
+## Understanding Counters
 
-### Understanding Counters
 ---
 
 Counters are exported as key-value pairs where the key is string and value is a
@@ -24,15 +23,16 @@ encoded with the following method:
 
 `<module-name>.<counter-name>.<stat-type>.<seconds>`
 
-For e.g.
+For example:
+
 - `kvstore.received_key_vals.sum.60` represents number of key-value updates that
   happened in past one minute
 - `decision.spf_runs.count.3600` represents number of SPF runs in last one hour
 - `decision.spf.multipath_ms.avg.0` represents the average execution time across
   all SPF calculations
 
-
 ### Important Counters to Monitor
+
 ---
 
 Here are some important counters to monitor for a production system and alert
@@ -40,6 +40,7 @@ engineers quickly if something goes wrong. `breeze monitor counters` will list
 a lot of other counters as well. Most names are self-explanatory.
 
 #### KvStore Counters
+
 - `kvstore.num_keys` => This counter shouldn't exceed a certain threshold and
   must have some max limit for a given network. If the number of keys keeps
   increasing in KvStore that means the system will soon run out of memory
@@ -48,6 +49,7 @@ a lot of other counters as well. Most names are self-explanatory.
   counter should be 0 most of time
 
 #### Spark Counters
+
 - `spark.num_tracked_interfaces` => Indicates the number of interfaces learned by
   OpenR
 - `spark.num_adjacent_neighbors` must match with `spark.num_tracked_neighbors`
@@ -76,7 +78,8 @@ a lot of other counters as well. Most names are self-explanatory.
 - `link_monitor.advertise_links.sum.60` => higher number indicates a lot of link
   flapping on system
 
-### Log Events
+## Log Events
+
 ---
 
 Along with counters OpenR also publishes certain log events. Each log event is a
@@ -85,12 +88,14 @@ json sample described as dictionary of
 `<value-type> => map<key, value>`
 
 Each sample has following keys along with more information
+
 - `int` key named `time` indicating timestamp since epoch in number of seconds.
 - `string` key named `domain` indicating network name
 - `string` key named `name` indicating name of the node
 - `string` key named `event` indicating event name
 
-Some important evens names are
+Some important evens names are:
+
 - `ROUTE_CALC`
 - `ROUTE_UPDATE`
 - `NB_RTT_CHANGE`

--- a/openr/docs/Operator_Guide/Runbook.md
+++ b/openr/docs/Operator_Guide/Runbook.md
@@ -1,5 +1,4 @@
-`Runbook - Configuration Guide for OpenR`
------------------------------------------
+# Runbook: The Configuration Guide for Open/R
 
 Good work on building and installing Open/R. Here are some ways you can run
 Open/R. You should have the `openr` C++ binary, `run_openr.sh` script, and
@@ -15,13 +14,14 @@ Checkout
 [Platform.thrift](https://github.com/facebook/openr/blob/master/openr/if/Platform.thrift)
 for more detail about these services.
 
-### Quick Start
+## Quick Start
+
 ---
 
 You can run the openr binary directly with some command line parameters and query
 links from it
 
-```
+```console
 // On shell-1
 $ openr --ifname_regex_include=eth.*
 
@@ -33,8 +33,12 @@ eth0         Up                                         2          169.254.0.13
                                                                    fe80::20a:f7ff:fe9a:3616
 ```
 
-### run_openr.sh and Configuration file
+## run_openr.sh and Configuration file
+
 ---
+
+> Open/R is currently *(202011)* moving to a thrift based JSON config file format so some of this
+documentation is out of date. This will be updated as soon as possible.
 
 The preferred way of running OpenR is via the  [run_openr.sh](https://github.com/facebook/openr/blob/master/openr/scripts/run_openr.sh)
 script. The benefit of it instead of directly passing parameters is that, it
@@ -54,12 +58,12 @@ VERBOSITY=1
 ```
 
 Run OpenR
-```
+```console
 $ run_openr.sh
 ```
 
 You can also pass in a custom configuration file and override/add openr flags:
-```
+```console
 $ run_openr.sh --help
 USAGE: run_openr.sh [config_file_path] [openr_flags]
 If config_file_path is not provided, we will source the one at /etc/sysconfig/openr
@@ -67,6 +71,7 @@ If openr_flags are provided, they will be passed along to openr and override any
 ```
 
 ### Running as a Daemon
+
 ---
 
 `openr` should be run as a daemon so that if it crashes or node gets restarted,
@@ -75,7 +80,7 @@ it as a `systemd` service. The following describes `openr.service` for systems
 supporting systemd. You can write one based on your platform very easily (as all
 it does is execute `run_openr.sh`).
 
-```
+```ini
 Description=Facebook Open Routing Platform
 After=network.target
 
@@ -96,19 +101,20 @@ StandardOutput=syslog
 WantedBy=multi-user.target
 ```
 
-### Configuration Options
+## Configuration Options
+
 ---
 
-#### OPENR
+### OPENR
 
 Path of `openr` binary on system. If binary is installed under searchable bin
 paths then you don't need any change here.
 
-```
+```shell
 OPENR=/usr/local/bin/openr
 ```
 
-#### DOMAIN
+### DOMAIN
 
 Name of domain this node is part of. OpenR will `only` form adjacencies to
 OpenR instances within it's own domain. This option becomes very useful if you
@@ -116,48 +122,48 @@ want to run OpenR on two nodes adjacent to each other but belonging to different
 domains, e.g. Data Center and Wide Area Network. Usually it should depict the
 Network.
 
-```
+```shell
 DOMAIN=cluster10.dc3
 ```
 
-#### LOOPBACK_IFACE
+### LOOPBACK_IFACE
 
 Indicates loopback address to which auto elected prefix will be assigned if
 enabled.
 
-```
+```shell
 LOOPBACK_IFACE=lo
 ```
 
-#### REDISTRIBUTE_IFACES
+### REDISTRIBUTE_IFACES
 
 Comma separated list of interface names whose `/32` (for v4) and `/128` (for v6)
 should be announced. OpenR will monitor address add/remove activity on this
 interface and announce it to rest of the network.
 
-```
+```shell
 REDISTRIBUTE_IFACES=lo1
 ```
 
-#### DECISION_GRACEFUL_RESTART_WINDOW_S
+### DECISION_GRACEFUL_RESTART_WINDOW_S
 
 Set time interval to wait for convergence before OpenR calculates routes and
 publishes them to the system. Set negative to disable this feature.
 
-```
+```shell
 DECISION_GRACEFUL_RESTART_WINDOW_S=60
 ```
 
-#### DRYRUN
+### DRYRUN
 
 OpenR will not try to program routes in it's default configuration. You should
 explicitly set this option to false to proceed with route programming.
 
-```
+```shell
 DRYRUN=true
 ```
 
-#### ENABLE_RTT_METRIC
+### ENABLE_RTT_METRIC
 
 Default mechanism for cost of a link is `1` and hence cost of path is hop
 count. With this option you can ask OpenR to compute and use RTT of a link as a
@@ -167,131 +173,130 @@ links will cause lot of churn in metric updates as measured RTT will fluctuate a
 lot because of packet processing overhead. RTT is measured at application level
 and hence the fluctuation for point-to-point links.
 
-```
+```shell
 ENABLE_RTT_METRIC=false
 ```
 
-#### ENABLE_V4
+### ENABLE_V4
 
 OpenR supports v4 as well but it needs to be turned on explicitly. It is
 expected that each interface will have v4 address configured for link local
 transport and v4/v6 topologies are congruent.
 
-```
+```shell
 ENABLE_V4=false
 ```
 
-#### DEPRECATED_ENABLE_SUBNET_VALIDATION
+### DEPRECATED_ENABLE_SUBNET_VALIDATION
 
 OpenR supports subnet validation to avoid mis-cabling of v4 addresses on
 different subnets on each end of the link. This is now by default enabled if v4 is enabled.
 
-```
+```shell
 ENABLE_SUBNET_VALIDATION=true
 ```
 
-#### ENABLE_LFA
+### ENABLE_LFA
 
 With this option, additional Loop-Free Alternate (LFA) routes can be computed,
 per RFC 5286, for fast failure recovery. Under the failure of all primary
 nexthops for a prefix, because of link failure, next best precomputed LFA will
 be used without need of an SPF run.
 
-```
+```shell
 ENABLE_LFA=false
 ```
 
-#### IFACE_REGEX_INCLUDE
+### IFACE_REGEX_INCLUDE
 
 Interface prefixes to perform neighbor discovery on. All interfaces whose
 names start with these are used for neighbor discovery.
 
-```
+```shell
 IFACE_REGEX_INCLUDE=eth.*,nic.*,po.*
 ```
 
-#### IFACE_REGEX_EXCLUDE
+### IFACE_REGEX_EXCLUDE
 
 Regex to exclude interface to perform neighbor discovery on. All interfaces whose
 names start with these are excluded for neighbor discovery.
 
-```
+```shell
 IFACE_REGEX_EXCLUDE=po[0-3]{3}
 ```
-#### MIN_LOG_LEVEL
+
+### MIN_LOG_LEVEL
 
 Log messages at or above this level. Again, the numbers of severity levels INFO,
 WARNING, ERROR, and FATAL are 0, 1, 2, and 3, respectively. Defaults to 0
 
-```
+```shell
 MIN_LOG_LEVEL=0
 ```
 
-
-#### VERBOSITY
+### VERBOSITY
 
 Show all verbose `VLOG(m)` messages for m less or equal the value of this flag.
 Use higher value for more verbose logging. Defaults to 1
 
-```
+```shell
 VERBOSITY=1
 ```
 
-
-#### ENABLE_PREFIX_ALLOC
+### ENABLE_PREFIX_ALLOC
 
 Enable prefix allocator to elect and assign a unique prefix for the node. You
 will need to specify other configuration parameters below.
 
-```
+```shell
 ENABLE_PREFIX_ALLOC=true
 ```
 
-#### SEED_PREFIX
+### SEED_PREFIX
 
 In order to elect a prefix for the node a super prefix to elect from is required.
 This is only applicable when `ENABLE_PREFIX_ALLOC` is set to true.
 
-```
+```shell
 SEED_PREFIX="face:b00c::/64"
 ```
 
-#### ALLOC_PREFIX_LEN
+### ALLOC_PREFIX_LEN
 
 Block size of allocated prefix in terms of it's prefix length. In this case
 `/80` prefix will be elected for a node. e.g. `face:b00c:0:0:1234::/80`
 
-```
+```shell
 ALLOC_PREFIX_LEN=80
 ```
 
-#### SET_LOOPBACK_ADDR
+### SET_LOOPBACK_ADDR
 
 If set to true along with `ENABLE_PREFIX_ALLOC` then second valid IP address of
 the block will be assigned onto `LOOPBACK_IFACE` interface. e.g. in this case
 `face:b00c:0:0:1234::1/80` will be assigned on `lo` interface.
 
-```
+```shell
 SET_LOOPBACK_ADDR=true
 ```
 
-#### OVERRIDE_LOOPBACK_ADDR
+### OVERRIDE_LOOPBACK_ADDR
 
 Whenever new address is elected for a node, before assigning it to interface
 all previously allocated prefixes or other global prefixes will be overridden
 with the new one. Use it with care!
 
-```
+```shell
 OVERRIDE_LOOPBACK_ADDR=false
 ```
 
-#### PREFIX_FWD_TYPE_MPLS
+### PREFIX_FWD_TYPE_MPLS
 
 Prefix type can be IP or SR_MPLS. Based on the type either IP next hop or MPLS
 label next hop is used for routing to the prefix. The type applies to both
 prefix address and redistributed interface address.
 
-#### PREFIX_FWD_ALGO_KSP2_ED_ECMP
+### PREFIX_FWD_ALGO_KSP2_ED_ECMP
 
 Boolean variable to change prefix forwarding algorithm from standard
 (Shortest path ECMP) to 2-Shortest-Path Edge Disjoint ECMP. Algorithm computes
@@ -304,69 +309,69 @@ destination prefix.
 
 `PREFIX_FWD_TYPE_MPLS` must be set if `PREFIX_FWD_ALGO_KSP2_ED_ECMP` is set.
 
-#### SPARK_HOLD_TIME_S
+### SPARK_HOLD_TIME_S
 
 Hold time indicating time in seconds from its last hello after which neighbor
 will be declared as down. Default value is `30 seconds`.
 
-```
+```shell
 SPARK_HOLD_TIME_S=30
 ```
 
-#### SPARK2_HELLO_TIME_S
+### SPARK2_HELLO_TIME_S
 
 How often to send helloMsg to neighbors. Default value is 20 seconds.
 
-```
+```shell
 SPARK2_HELLO_TIME_S=20
 ```
 
-#### SPARK2_HELLO_FASTINIT_MS
+### SPARK2_HELLO_FASTINIT_MS
 
 When interface is detected UP, OpenR can perform fast initial neighbor discovery.
 Default value is 500 which means neighbor will be discovered within 1s on a link.
 
-```
+```shell
 SPARK2_HELLO_FASTINIT_MS=500
 ```
 
-#### SPARK2_HEARTBEAT_TIME_S
+### SPARK2_HEARTBEAT_TIME_S
 
 heartbeatMsg are used to detect if neighbor is up running when adjacency is established
 Default value is 2s.
 
-```
+```shell
 SPARK2_HEARTBEAT_TIME_S=2
 ```
 
-#### SPARK2_HEARTBEAT_HOLD_TIME_S
+### SPARK2_HEARTBEAT_HOLD_TIME_S
 
 Expiration time if node does NOT receive 'keepAlive' info from neighbor node.
 Default value is 10s.
 
-```
+```shell
 SPARK2_HEARTBEAT_HOLD_TIME_S=10
 ```
 
-#### ENABLE_NETLINK_FIB_HANDLER
+### ENABLE_NETLINK_FIB_HANDLER
 
 Knob to enable/disable default implementation of `FibService` that comes along
 with OpenR for Linux platform. If you want to run your own FIB service then
 disable this option
 
-```
+```shell
 ENABLE_NETLINK_FIB_HANDLER=true
 ```
 
-#### FIB_HANDLER_PORT
+### FIB_HANDLER_PORT
 
 TCP port on which `FibService` will be listening.
 
-```
+```shell
 FIB_HANDLER_PORT=60100
 ```
 
-#### DECISION_DEBOUNCE_MIN_MS / DECISION_DEBOUNCE_MAX_MS
+### DECISION_DEBOUNCE_MIN_MS / DECISION_DEBOUNCE_MAX_MS
 
 Knobs to control how often to run Decision. On receipt of first even debounce
 is created with MIN time which grows exponentially up to max if there are more
@@ -374,12 +379,12 @@ events before debounce is executed. This helps us to react to single network
 failures quickly enough (with min duration) while avoid high CPU utilization
 under heavy network churn.
 
-```
+```shell
 DECISION_DEBOUNCE_MIN_MS=10
 DECISION_DEBOUNCE_MAX_MS=250
 ```
 
-#### SET_LEAF_NODE
+### SET_LEAF_NODE
 
 Sometimes a node maybe a leaf node and have only one path in to network. This
 node does not require to keep track of the entire topology. In this case, it may
@@ -390,22 +395,22 @@ Setting this flag enables key prefix filters defined by KEY_PREFIX_FILTERS.
 A node only tracks keys in kvstore that matches one of the prefixes in
 KEY_PREFIX_FILTERS.
 
-```
+```shell
 SET_LEAF_NODE=false
 ```
 
-#### KEY_PREFIX_FILTERS
+### KEY_PREFIX_FILTERS
 
 This comma separated string is used to set the key prefixes when key prefix
 filter is enabled (See SET_LEAF_NODE).
 It is also set when requesting KEY_DUMP from peer to request keys that match
 one of these prefixes.
 
-```
+```shell
 KEY_PREFIX_FILTERS="foo,bar"
 ```
 
-#### ENABLE_PERF_MEASUREMENT
+### ENABLE_PERF_MEASUREMENT
 
 Experimental feature to measure convergence performance. Performance information
 can be viewed via breeze API `breeze perf fib`
@@ -416,22 +421,22 @@ Experimental and partially implemented segment routing feature. As of now it
 only elects node/adjacency labels. In future we will extend it to compute and
 program FIB routes.
 
-```
+```shell
 ENABLE_SEGMENT_ROUTING=false
 ```
 
-#### IP_TOS
+### IP_TOS
 
 Set type of service (TOS) value with which every control plane packet from
 Open/R will be marked with. This marking can be used to prioritize control plane
 traffic (as compared to data plane) so that congestion in network doesn't affect
 operations of Open/R
 
-```
+```shell
 IP_TOS=192
 ```
 
-#### MEMORY_LIMIT_MB
+### MEMORY_LIMIT_MB
 
 Enforce upper limit on amount of memory in mega-bytes that open/r process can
 use. Above this limit watchdog thread will trigger crash. Service can be
@@ -439,21 +444,22 @@ auto-restarted via system or some kind of service manager. This is very useful
 to guarantee protocol doesn't cause trouble to other services on device where
 it runs and takes care of slow memory leak kind of issues.
 
-```
+```shell
 MEMORY_LIMIT_MB=300
 ```
-#### KVSTORE_KEY_TTL_MS
+
+### KVSTORE_KEY_TTL_MS
 
 Set the TTL (in ms) of a key in the KvStore. For larger networks where burst of
 updates can be high having high value makes sense. For smaller networks where
 burst of updates are low, having low value makes more sense.
 Defaults to 300000 (5 min).
 
-```
+```shell
 KVSTORE_KEY_TTL_MS=300000
 ```
 
-#### KVSTORE_ZMQ_HWM
+### KVSTORE_ZMQ_HWM
 
 Set buffering size for KvStore socket communication. Updates to neighbor
 node during flooding can be buffered upto this number. For larger networks where
@@ -461,11 +467,11 @@ burst of updates can be high having high value makes sense. For smaller networks
 where burst of updates are low, having low value makes more sense.
 Defaults to 65536.
 
-```
+```shell
 KVSTORE_ZMQ_HWM=65536
 ```
 
-#### ENABLE_FLOOD_OPTIMIZATION
+### ENABLE_FLOOD_OPTIMIZATION
 
 Set this true to enable flooding-optimization, Open/R will start forming
 spanning tree and flood updates on formed SPT instead of physical
@@ -476,11 +482,11 @@ will be the path between two nodes in the formed SPT, which is not necessary to
 be the shortest path. (worst case: 2 x SPT-depth between two leaf nodes).
 data-plane traffic stays the same.
 
-```
+```shell
 ENABLE_FLOOD_OPTIMIZATION=false
 ```
 
-#### IS_FLOOD_ROOT
+### IS_FLOOD_ROOT
 
 Set this true to let this node declare itself as a flood-root. You can set
 multiple nodes as flood-roots in a network, in steady state, open/r will pick
@@ -488,11 +494,11 @@ optimal (smallest node-name) one as the SPT for flooding. If optimal root went
 away, open/r will pick 2nd optimal one as SPT-root and so on so forth. If all
 root nodes went away, open/r will fall back to naive flooding.
 
-```
+```shell
 IS_FLOOD_ROOT=false
 ```
 
-### TLS Related Flags
+## TLS Related Flags
 
 We are in the process of adding TLS for all openr traffic. This will be
 implemented with secure [Thrift](https://github.com/facebook/fbthrift).
@@ -504,41 +510,41 @@ reachable.
 To enable security, please pass the flags detailed below. For authentication,
 specify acceptable common names via TLS_ACCEPTABLE_PEERS
 
-#### ENABLE_SECURE_THRIFT_SERVER
+### ENABLE_SECURE_THRIFT_SERVER
 
 Flag to enable TLS for our thrift server. Disable this for plaintext thrift.
 
-#### X509_CERT_PATH
+### X509_CERT_PATH
 
 If we are running an SSL thrift server, this option specifies the certificate
 path for the associated wangle::SSLContextConfig
 
-#### X509_KEY_PATH
+### X509_KEY_PATH
 
 If we are running an SSL thrift server, this option specifies the key path for
 the associated wangle::SSLContextConfig
 
-#### X509_CA_PATH
+### X509_CA_PATH
 
 If we are running an SSL thrift server, this option specifies the certificate
 authority path for verifying peers
 
-#### TLS_TICKET_SEED_PATH
+### TLS_TICKET_SEED_PATH
 
 If we are running an SSL thrift server, this option specifies the TLS ticket
 seed file path to use for client session resumption
 
-#### ECC_CURVE_NAME
+### ECC_CURVE_NAME
 
 If we are running an SSL thrift server, this option specifies the eccCurveName
 for the associated wangle::SSLContextConfig
 
-#### TLS_ACCEPTABLE_PEERS
+### TLS_ACCEPTABLE_PEERS
 
 A comma separated list of strings. Strings are x509 common names to accept SSL
 connections from.
 
-### Link Backoff - Improving Stabilility of Link State
+## Link Backoff - Improving Stability of Link State
 
 Network can have some bad links that can keep flapping because of bad hardware
 or environment (in case of wireless links). A single link flap event on one node
@@ -550,7 +556,7 @@ Enabling link backoff can alleviate this problem. Main idea is to let link prove
 itself stable for expected amount of time before using it. The duration to prove
 stability increases with every flap within max-backoff.
 
-#### LINK_FLAP_INITIAL_BACKOFF_MS
+### LINK_FLAP_INITIAL_BACKOFF_MS
 
 When link goes down after being stable/up for long time, then the backoff is
 applied.
@@ -561,9 +567,10 @@ applied.
 - When backoff is cleared then actual status of link is used. If UP link then
   neighbor discovery is performed else Open/R will wait for link to come up.
 
-#### LINK_FLAP_MAX_BACKOFF_MS
+### LINK_FLAP_MAX_BACKOFF_MS
 
 Serves two purposes
+
 - This is the maximum backoff a link gets penalized with by consecutive flaps
 - When the first backoff time has passed and the link is in UP state, the next
   time the link goes down within `LINK_FLAP_MAX_BACKOFF_MS`, the new backoff

--- a/openr/docs/Operator_Guide/Versions.md
+++ b/openr/docs/Operator_Guide/Versions.md
@@ -1,12 +1,15 @@
-# `Versioning`
+# Versioning
+
 ---
 
 This page describes the major changes inside Open/R including:
+
 - New feature support being added
 - Feature support being dropped
 - Non backward-compatible changes in message format/CLI interface/etc.
 
-### Overview of Version Usage
+## Overview of Version Usage
+
 ---
 
 Open/R use `SparkHelloMsg` to carry `version` attribute during neighbor
@@ -16,6 +19,7 @@ locally. Both `version` and `lowestSupportedVersion` are of `uint32_t` type.
 
 In Open/R, version will be specified according to the timestamp with granularity
 of `day`. Samples are:
+
 - version: `20200825`
 - lowestSupportedVersion: `20200214`
 
@@ -23,9 +27,11 @@ See [Spark.md](../Protocol_Guide/Spark.md)
 for more details about neighbor discivery mechanism inside `Spark`.
 
 ### Backward Compatibility
+
 ---
 
 There are multiple aspects of backward comaptibility concern within Open/R:
+
 - Message exchanged between `Spark` instances for adjacency establishment;
 - Message exchanged between `KvStore` instances for data consistency globally;
 - `breeze` CLI interface between client and server;
@@ -36,25 +42,26 @@ regarding to messgaes between `Spark` neighbor and `KvStore` peers. This is to
 make sure core functionality of Open/R can be fulfilled without interruption.
 
 ### Version History
+
 ---
 
-* Version 20200825
+- Version 20200825
   - Platform publisher service with ZMQ PUB/SUB deprecated
 
-* Version 20200801
+- Version 20200801
   - System service deprecated
 
-* Version 20200701
+- Version 20200701
   - Area feature becomes mandatory
 
-* Version 20200604
+- Version 20200604
   - Old Spark feature deprecated
 
-* Version 20200421
+- Version 20200421
   - Spark AREA feature support
 
-* Version  20191010
+- Version  20191010
   - Spark2 feature support
 
-* Version  20190805
+- Version  20190805
   - Per prefix key feature support


### PR DESCRIPTION
- Remove remaining `# `HEADINGS`` to obtain consistent formatting across all docs
- Fix CLI.md console output rendering
  - Had to remove some "'" chars as it confused console Markdown renderer with sphinx
  - Fix heading usage (change # count)
- Mark runbook with out of date disclaimer due to Thrift JSON Config coming ...

Test Plan:
- `make linkcheck ; echo $?`
- `make html ; echo $?`