### PR TITLE
Fix Links to make linkcheck pass

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -20,10 +20,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
 
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
 
       - name: Link check markdown + yaml with prettier
         run: |

--- a/openr/docs/Features/SourceRouting.md
+++ b/openr/docs/Features/SourceRouting.md
@@ -201,6 +201,6 @@ kernel.
 - [IPv6 Segment Routing Header (SRH)](https://tools.ietf.org/html/rfc8754)
 - [Segment Routing with the MPLS Data Plane](https://tools.ietf.org/html/rfc8660)
 - [Intro to Segment Routing](https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/seg_routing/configuration/xe-3s/segrt-xe-3s-book/intro-seg-routing.pdf)
-- [Segment Routing in Linux Kernel](http://www.segment-routing.net/open-software/linux/)
+- [Segment Routing in Linux Kernel](https://www.segment-routing.net/open-software/linux/)
 - [MPLS Tutorial for Linux](https://netdevconf.info/1.1/proceedings/slides/prabhu-mpls-tutorial.pdf)
 - [MPLS in GRE Tunnel on Linux](https://jsteward.moe/mpls-in-gre-tunnel-linux.html)

--- a/openr/docs/Protocol_Guide/PrefixAllocator.md
+++ b/openr/docs/Protocol_Guide/PrefixAllocator.md
@@ -18,7 +18,7 @@ NOTE: This functionality is deprecated and will soon be removed from Open/R
 ---
 
 See
-[Range Allocator Inter-Module Communication](RangeAllocator.md#inter-module-cmmunication)
+[Range Allocator Inter-Module Communication](RangeAllocator.md) section
 
 ## Configuration
 

--- a/openr/docs/Protocol_Guide/PrefixAllocator.md
+++ b/openr/docs/Protocol_Guide/PrefixAllocator.md
@@ -17,8 +17,7 @@ NOTE: This functionality is deprecated and will soon be removed from Open/R
 
 ---
 
-See
-[Range Allocator Inter-Module Communication](RangeAllocator.md) section
+See [Range Allocator Inter-Module Communication](RangeAllocator.md) section
 
 ## Configuration
 


### PR DESCRIPTION
Description:
- Fix links that made linkcheck unhappy
- Also remove specifying python version and just update as new pythons come out for doc lint

Test Plan:
- Run `linkcheck` locally