### PR TITLE
Have Docker builds use local source

### DIFF
--- a/build/build_openr.sh
+++ b/build/build_openr.sh
@@ -28,9 +28,8 @@ fi
 # python3 "$GETDEPS" --allow-system-packages install-system-deps --recursive openr
 # errorCheck "Failed to install-system-deps for openr"
 
-python3 "$GETDEPS" --allow-system-packages build --no-tests --install-prefix "$INSTALL_PREFIX" openr
+python3 "$GETDEPS" --allow-system-packages build --src-dir=. --no-tests --install-prefix "$INSTALL_PREFIX" openr
 errorCheck "Failed to build openr"
 
-# TODO: Maybe fix src-dir to be absolute reference to dirname $0's parent
 python3 "$GETDEPS" fixup-dyn-deps --strip --src-dir=. openr _artifacts/linux  --project-install-prefix openr:"$INSTALL_PREFIX" --final-install-prefix "$INSTALL_PREFIX"
 errorCheck "Failed to fixup-dyn-deps for openr"


### PR DESCRIPTION
- This helps actually test branches and non master changes before being landed
- This is more natural behavior as one would expect

Test Plan:
- Build with Docker