### PR TITLE
Fix erroneus documentation for rtt calculation

### DIFF
--- a/openr/docs/Protocol_Guide/LinkMonitor.md
+++ b/openr/docs/Protocol_Guide/LinkMonitor.md
@@ -136,7 +136,7 @@ to neighbors which are then used to compute the cost of a path in `Decision`'s
 SPF computation. For now, we support two kinds of metrics:
 
 - [by default] `hop_count` => Use `1` (constant) metric value for each Adjacency
-- [by config knob] `rtt_metric` => `rtt_us / 10` where `rtt_us` is measured rtt
+- [by config knob] `rtt_metric` => `rtt_us / 100` where `rtt_us` is measured rtt
   in microseconds.
 
 > NOTE: `rtt` is measured dynamically by `Spark` as part of neighbor discovery


### PR DESCRIPTION
getRttMetric is using rttUs / 100 since 2017 not / 10 for metric
computation

