### PR TITLE
Fix typo in wiki of KvStore

### DIFF
--- a/openr/docs/Protocol_Guide/KvStore.md
+++ b/openr/docs/Protocol_Guide/KvStore.md
@@ -80,7 +80,7 @@ getKvStoreKeyVals(std::string area, thrift::KeyGetParams keyGetParams)
  * @return: None
  */
 void
-setKvStoreKeyVals(std::string area, thrift::KeyGetParams keyGetParams)
+setKvStoreKeyVals(std::string area, thrift::KeySetParams keySetParams)
 
 /*
  * @params: area => single areaId to set K-V pairs


### PR DESCRIPTION
Fix variable typo in documentation.
