### PR TITLE
feat: add support for compiling open/r on 64-bit arm linux

### DIFF
--- a/build/fbcode_builder/getdeps/builder.py
+++ b/build/fbcode_builder/getdeps/builder.py
@@ -185,6 +185,12 @@ class MakeBuilder(BuilderBase):
         self._run_cmd(cmd, env=env)
 
 
+class CMakeBootStrapBuilder(MakeBuilder):
+    def _build(self, install_dirs, reconfigure):
+        self._run_cmd(["./bootstrap", "--prefix=" + self.inst_dir])
+        super(CMakeBootStrapBuilder, self)._build(install_dirs, reconfigure)
+
+
 class AutoconfBuilder(BuilderBase):
     def __init__(self, build_opts, ctx, manifest, src_dir, build_dir, inst_dir, args):
         super(AutoconfBuilder, self).__init__(
@@ -868,7 +874,9 @@ class OpenSSLBuilder(BuilderBase):
             args = ["darwin64-x86_64-cc"]
         elif self.build_opts.is_linux():
             make = "make"
-            args = ["linux-x86_64"]
+            args = (
+                ["linux-x86_64"] if not self.build_opts.is_arm() else ["linux-aarch64"]
+            )
         else:
             raise Exception("don't know how to build openssl for %r" % self.ctx)
 

--- a/build/fbcode_builder/getdeps/buildopts.py
+++ b/build/fbcode_builder/getdeps/buildopts.py
@@ -141,6 +141,9 @@ class BuildOptions(object):
     def is_windows(self):
         return self.host_type.is_windows()
 
+    def is_arm(self):
+        return self.host_type.is_arm()
+
     def get_vcvars_path(self):
         return self.vcvars_path
 

--- a/build/fbcode_builder/getdeps/manifest.py
+++ b/build/fbcode_builder/getdeps/manifest.py
@@ -21,6 +21,7 @@ from .builder import (
     OpenNSABuilder,
     OpenSSLBuilder,
     SqliteBuilder,
+    CMakeBootStrapBuilder,
 )
 from .expr import parse_expr
 from .fetcher import (
@@ -437,21 +438,34 @@ class ManifestParser(object):
                 build_dir = os.path.join(build_dir, subdir)
             print("build_dir is %s" % build_dir)  # just to quiet lint
 
-        if builder == "make":
+        if builder == "make" or builder == "cmakebootstrap":
             build_args = self.get_section_as_args("make.build_args", ctx)
             install_args = self.get_section_as_args("make.install_args", ctx)
             test_args = self.get_section_as_args("make.test_args", ctx)
-            return MakeBuilder(
-                build_options,
-                ctx,
-                self,
-                src_dir,
-                None,
-                inst_dir,
-                build_args,
-                install_args,
-                test_args,
-            )
+            if builder == "cmakebootstrap":
+                return CMakeBootStrapBuilder(
+                    build_options,
+                    ctx,
+                    self,
+                    src_dir,
+                    None,
+                    inst_dir,
+                    build_args,
+                    install_args,
+                    test_args,
+                )
+            else:
+                return MakeBuilder(
+                    build_options,
+                    ctx,
+                    self,
+                    src_dir,
+                    None,
+                    inst_dir,
+                    build_args,
+                    install_args,
+                    test_args,
+                )
 
         if builder == "autoconf":
             args = self.get_section_as_args("autoconf.args", ctx)

--- a/build/fbcode_builder/getdeps/platform.py
+++ b/build/fbcode_builder/getdeps/platform.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import re
 import shlex
 import sys
+import platform
 
 
 def is_windows():
@@ -70,9 +71,17 @@ class HostType(object):
         self.distro = distro
         # The OS/distro version if known
         self.distrovers = distrovers
+        machine = platform.machine().lower()
+        if "arm" in machine or "aarch" in machine:
+            self.isarm = True
+        else:
+            self.isarm = False
 
     def is_windows(self):
         return self.ostype == "windows"
+
+    def is_arm(self):
+        return self.isarm
 
     def is_darwin(self):
         return self.ostype == "darwin"

--- a/build/fbcode_builder/manifests/cmake
+++ b/build/fbcode_builder/manifests/cmake
@@ -20,8 +20,8 @@ url = https://github.com/Kitware/CMake/releases/download/v3.14.0/cmake-3.14.0-Da
 sha256 = a02ad0d5b955dfad54c095bd7e937eafbbbfe8a99860107025cc442290a3e903
 
 [download.os=linux]
-url = https://github.com/Kitware/CMake/releases/download/v3.14.0/cmake-3.14.0-Linux-x86_64.tar.gz
-sha256 = 91dc9af7345e458eb10c853aa875e591efb7079a045641685ddec8d973c2b2bc
+url = https://github.com/Kitware/CMake/releases/download/v3.14.0/cmake-3.14.0.tar.gz
+sha256 = aa76ba67b3c2af1946701f847073f4652af5cbd9f141f221c97af99127e75502
 
 [build.os=windows]
 builder = nop
@@ -36,5 +36,8 @@ CMake.app/Contents/bin = bin
 CMake.app/Contents/share = share
 
 [build.os=linux]
-builder = nop
-subdir = cmake-3.14.0-Linux-x86_64
+builder = cmakebootstrap
+subdir = cmake-3.14.0
+
+[make.install_args.os=linux]
+install


### PR DESCRIPTION
Description:

Prior to this patch it was not possible to run open/r on linux running on ARM due to cmake and openssl being harded to download/compile for the x86_64 arch.

In order to prevent such problem this patch actively compiles cmake instead of using pre-compiled binaries and also allows the OpenSSLBuilder to provide the correct build args to openssl, thus not trying to compile or run x86_64 software. 

Test Plan:

* built the project by using ./build/build_openr.sh
