### PR TITLE
openr: add explicit boost component dependancies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,10 @@ set(
 include(FBThriftCppLibrary)
 include(FBGenCMakeBuildInfo)
 
+set(REQ_BOOST_COMPONENTS ${REQ_BOOST_COMPONENTS} system thread context filesystem program_options regex)
+
 find_library(ASYNC async PATHS)
-find_package(Boost REQUIRED COMPONENTS system context)
+find_package(Boost REQUIRED COMPONENTS ${REQ_BOOST_COMPONENTS})
 find_library(CONCURRENCY concurrency PATHS)
 find_library(DOUBLE-CONVERSION double-conversion)
 find_package(fbzmq REQUIRED)


### PR DESCRIPTION
openr: add explicit boost component dependancies

When compiling on ubuntu 20.04 build fails on fbzmq and openr with the same issue. 
Adding explicit boost dependancies seems to solve it. No such issue on debian builds however.

Excerpt of error messages:
```
CMake Error at CMakeLists.txt:263 (add_executable):
  Target "openr_bin" links to target "Boost::filesystem" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?

CMake Error at CMakeLists.txt:263 (add_executable):
  Target "openr_bin" links to target "Boost::program_options" but the target
  was not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?

CMake Error at CMakeLists.txt:263 (add_executable):
  Target "openr_bin" links to target "Boost::regex" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?

CMake Error at CMakeLists.txt:263 (add_executable):
  Target "openr_bin" links to target "Boost::thread" but the target was not
```
