### PR TITLE
Raise PrefixAllocator Iface Exception so Retries Occur

### DIFF
--- a/openr/allocators/PrefixAllocator.cpp
+++ b/openr/allocators/PrefixAllocator.cpp
@@ -656,7 +656,7 @@ PrefixAllocator::updateMyPrefix(folly::CIDRNetwork prefix) {
     LOG(ERROR)
         << "Failed to get iface addresses from NetlinkSystemHandler. Error: "
         << folly::exceptionStr(e);
-    return;
+    throw e;
   }
 
   // desired global prefixes


### PR DESCRIPTION
# Pull Request Template

Title:Raise PrefixAllocator Iface Exception so Retries Occur

Description:

During TG Puma startup the PrefixAllocator module assigns `lo` an IP address. It makes a call the Netlink thread. If the call fails because the Netlink thread isn't ready, PrefixAllocator will not attempt to retry the call. Raise the timeout exception so that PrefixAllocator retries

Test Plan:

Run on TG dry-run network
