### PR TITLE
Fix invalid JSON in example .conf

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ possible.
 
 We actively welcome your pull requests.
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.

--- a/example_openr.conf
+++ b/example_openr.conf
@@ -25,7 +25,7 @@
     "prefix_forwarding_algorithm": 0,
     "kvstore_config": {
         "key_ttl_ms": 600000,
-        "ttl_decrement_ms": 1,
+        "ttl_decrement_ms": 1
     },
     "link_monitor_config": {
         "linkflap_initial_backoff_ms": 60000,


### PR DESCRIPTION
Title: Fix invalid JSON in example .conf

Description:

Correct typo in `example_openr.conf`
```
$ python -mjson.tool example_openr.conf
Expecting property name: line 29 column 5 (char 729)
```

Test Plan:

Parsed and loaded valid .conf
