### PR TITLE
regenerate GitHub actions for all projects

### DIFF
--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -49,22 +49,20 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests automake
     - name: Fetch libtool
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libtool
-    - name: Fetch bison
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests bison
     - name: Fetch libsodium
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libsodium
-    - name: Fetch xz
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests xz
-    - name: Fetch folly
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests folly
-    - name: Fetch fizz
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
     - name: Fetch libffi
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libffi
     - name: Fetch ncurses
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests ncurses
     - name: Fetch python
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests python
+    - name: Fetch xz
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests xz
+    - name: Fetch folly
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests folly
+    - name: Fetch fizz
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
     - name: Fetch wangle
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests wangle
     - name: Fetch fbthrift
@@ -111,22 +109,20 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --no-tests automake
     - name: Build libtool
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libtool
-    - name: Build bison
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests bison
     - name: Build libsodium
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libsodium
-    - name: Build xz
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests xz
-    - name: Build folly
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
-    - name: Build fizz
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
     - name: Build libffi
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libffi
     - name: Build ncurses
       run: python3 build/fbcode_builder/getdeps.py build --no-tests ncurses
     - name: Build python
       run: python3 build/fbcode_builder/getdeps.py build --no-tests python
+    - name: Build xz
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests xz
+    - name: Build folly
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
+    - name: Build fizz
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
     - name: Build wangle
       run: python3 build/fbcode_builder/getdeps.py build --no-tests wangle
     - name: Build fbthrift


### PR DESCRIPTION
Summary:
After D38831140 (https://github.com/facebook/openr/commit/4022c77a8c319a65f394fa53dc29608d8b0d63bb), `bison` no longer needs to be fetched by most
projects.

Differential Revision: D38877152

