### PR TITLE
Fix snappy RTTI linker error in open-source CI

### DIFF
--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -87,6 +87,9 @@ jobs:
     - name: Fetch snappy
       if: ${{ steps.paths.outputs.snappy_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests snappy
+    - name: Patch snappy to restore RTTI (google/snappy#184)
+      if: ${{ steps.paths.outputs.snappy_SOURCE }}
+      run: sed -i 's/-fno-rtti//g' ${{ steps.paths.outputs.snappy_SOURCE }}/CMakeLists.txt
     - name: Fetch range-v3
       if: ${{ steps.paths.outputs.range-v3_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests range-v3


### PR DESCRIPTION
Summary:
Snappy >= 1.1.9 disables RTTI by default via `set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")` in its CMakeLists.txt (google/snappy#184). This causes `undefined reference to typeinfo for snappy::Source` when linking openr binaries, because folly's compression module (compiled with RTTI) references snappy's typeinfo which the RTTI-stripped `libsnappy.so` doesn't export.

The previous approach of passing `CMAKE_CXX_FLAGS=-frtti` via `--extra-cmake-defines` does not work because snappy's CMakeLists.txt explicitly strips any existing `-frtti` before appending `-fno-rtti`.

Fix: add a workflow step after fetching snappy that patches its CMakeLists.txt to remove `-fno-rtti`, restoring the GCC default (RTTI enabled). This is the same approach used by Fedora, Debian, and openSUSE to work around google/snappy#184.

Differential Revision: D107163112


