### PR TITLE
build_openr.sh: build the local checkout via --src-dir=.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ RUN mkdir /src
 ADD CMakeLists.txt FBGenCMakeBuildInfo.cmake ThriftLibrary.cmake /src/
 COPY build /src/build
 COPY openr /src/openr
+# OpenR's CMakeLists builds routing_policy.thrift / vip_service_config.thrift
+# from configerator/structs/neteng/config/. These must be present in /src for
+# the --src-dir=. build below; previously they were only available because
+# getdeps cloned the full upstream repo.
+COPY configerator /src/configerator
 COPY example_openr.conf /etc/openr.conf
 
 # Build OpenR + Dependencies via cmake

--- a/build/build_openr.sh
+++ b/build/build_openr.sh
@@ -11,7 +11,11 @@ source "$(dirname "$0")/common.sh"
 # "$PYTHON3" "$GETDEPS" --allow-system-packages install-system-deps --recursive openr
 # errorCheck "Failed to install-system-deps for openr"
 
-"$PYTHON3" "$GETDEPS" --allow-system-packages build --no-tests --install-prefix "$INSTALL_PREFIX" \
+# --src-dir=. builds the Open/R sources present in this checkout (the Dockerfile
+# COPYs them into /src and runs this script from there). Without it, getdeps
+# clones the canonical repo from the manifest's repo_url at a pinned revision
+# and ignores the local source, so local changes never get built.
+"$PYTHON3" "$GETDEPS" --allow-system-packages build --src-dir=. --no-tests --install-prefix "$INSTALL_PREFIX" \
 --extra-cmake-defines "$EXTRA_CMAKE_DEFINES" openr
 errorCheck "Failed to build openr"
 


### PR DESCRIPTION
Summary:
The Open/R OSS Docker build (`openr/public_tld/Dockerfile`) `COPY`s the repo into `/src` and runs `cd /src && build/build_openr.sh`. But the getdeps `build` invocation in `build_openr.sh` was missing `--src-dir`, so getdeps cloned the canonical `https://github.com/facebook/openr.git` (from the manifest `repo_url`) at a pinned revision and built that instead of the `COPY`ed source. The runtime banner gave it away: `Build path: /root/scratch/repos/github.com-facebook-openr.git`, `Build Revision: 292abe6` — i.e. local changes baked into the image were silently ignored.

Add `--src-dir=.` to the `build` command so getdeps builds the Open/R sources in the checkout. This matches what the same script's `fixup-dyn-deps` line already does (`--src-dir=.`) and what the GitHub Actions workflow (`getdeps_linux.yml`) does (`getdeps.py build --src-dir=. openr`). Dependencies are still fetched/pinned by getdeps as before; only the top-level Open/R project now comes from the local tree.

Differential Revision: D108239680


